### PR TITLE
Fix crash when we would encrypt / decrypt in nested perform block

### DIFF
--- a/Cryptobox/EncryptionContext.swift
+++ b/Cryptobox/EncryptionContext.swift
@@ -78,6 +78,9 @@ public class EncryptionContext : NSObject {
     /// Folder file descriptor
     private var fileDescriptor : CInt!
     
+    
+    private var performCount : UInt = 0
+    
     /// Opens cryptobox from a given folder
     /// - throws: CryptoBox error in case of lower-level error
     public init(path: NSURL) {
@@ -106,7 +109,8 @@ public class EncryptionContext : NSObject {
 
 // MARK: - Start and stop using sessions
 extension EncryptionContext {
-        
+    
+    
     /// Access sessions and other data in this context. While the block is executed,
     /// no other process can use sessions from this context. If another process or thread is already
     /// using sessions from a context with the same path, this call will block until the other process
@@ -118,8 +122,12 @@ extension EncryptionContext {
         if self.currentSessionsDirectory == nil {
             self.currentSessionsDirectory = EncryptionSessionsDirectory(generatingContext: self)
         }
+        performCount += 1
         block(sessionsDirectory: self.currentSessionsDirectory!)
-        self.currentSessionsDirectory = nil
+        performCount -= 1
+        if 0 == performCount {
+            self.currentSessionsDirectory = nil
+        }
         self.releaseDirectoryLock()
     }
     

--- a/CryptoboxTests/EncryptionContextTests.swift
+++ b/CryptoboxTests/EncryptionContextTests.swift
@@ -147,6 +147,35 @@ class EncryptionContextTests: XCTestCase {
         self.waitForExpectationsWithTimeout(0) { _ in }
     }
     
+    func testThatItSafelyEncryptDecryptDuringNestedPerform() {
+        
+        // GIVEN
+        let tempDir = createTempFolder()
+        
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        let someTextToEncrypt = "ENCRYPT THIS!"
+        
+        // WHEN
+        
+        // enter critical section
+        mainContext.perform { context1 in
+            
+            try! context1.createClientSession(hardcodedClientId, base64PreKeyString: hardcodedPrekey)
+            
+            mainContext.perform { context2 in
+                try! context2.encrypt(someTextToEncrypt.dataUsingEncoding(NSUTF8StringEncoding)!, recipientClientId: hardcodedClientId)
+                
+            }
+            
+            try! context1.encrypt(someTextToEncrypt.dataUsingEncoding(NSUTF8StringEncoding)!, recipientClientId: hardcodedClientId)
+        }
+        
+        // THEN 
+        // it didn't crash
+    }
+
+    
     func testThatItDoesNotReceivesTheSameSessionStatusIfDonePerforming() {
         
         // GIVEN


### PR DESCRIPTION
**What's in this PR**
We were crashing when encrypting / decrypting a message in nested `perform` call, because the 1st block to return would destroy the `EncryptionSessionDirectory`.
We now count until the very last exit before destroying it.