### PR TITLE
Throw new @objc error type for proper interop

### DIFF
--- a/Cryptobox/CryptoBoxError.swift
+++ b/Cryptobox/CryptoBoxError.swift
@@ -22,3 +22,79 @@ import Foundation
 extension CBoxResult : ErrorType {
 }
 
+@objc public enum CryptoboxError : UInt32, ErrorType {
+    
+    case CryptoboxSuccess                 = 0
+    
+    case CryptoboxStorageError            = 1
+    
+    case CryptoboxSessionNotFound         = 2
+    
+    case CryptoboxDecodeError             = 3
+    
+    case CryptoboxRemoteIdentityChanged   = 4
+    
+    case CryptoboxInvalidSignature        = 5
+    
+    case CryptoboxInvalidMessage          = 6
+    
+    case CryptoboxDuplicateMessage        = 7
+    
+    case CryptoboxTooDistantFuture        = 8
+    
+    case CryptoboxOutdatedMessage         = 9
+    
+    case CryptoboxUTF8Error               = 10
+    
+    case CryptoboxNulError                = 11
+    
+    case CryptoboxEncodeError             = 12
+    
+    case CryptoboxIdentityError           = 13
+    
+    case CryptoboxPrekeyNotFound          = 14
+    
+    case CryptoboxPanic                   = 15
+    
+    
+    public init?(rawValue: UInt32)
+    {
+        switch rawValue {
+        case CBOX_SUCCESS.rawValue:
+            self = .CryptoboxSuccess
+        case CBOX_STORAGE_ERROR.rawValue:
+            self = .CryptoboxStorageError
+        case CBOX_SESSION_NOT_FOUND.rawValue:
+            self = .CryptoboxSessionNotFound
+        case CBOX_DECODE_ERROR.rawValue:
+            self = .CryptoboxDecodeError
+        case CBOX_REMOTE_IDENTITY_CHANGED.rawValue:
+            self = .CryptoboxRemoteIdentityChanged
+        case CBOX_INVALID_SIGNATURE.rawValue:
+            self = .CryptoboxInvalidSignature
+        case CBOX_INVALID_MESSAGE.rawValue:
+            self = .CryptoboxInvalidMessage
+        case CBOX_DUPLICATE_MESSAGE.rawValue:
+            self = .CryptoboxDuplicateMessage
+        case CBOX_TOO_DISTANT_FUTURE.rawValue:
+            self = .CryptoboxTooDistantFuture
+        case CBOX_OUTDATED_MESSAGE.rawValue:
+            self = .CryptoboxOutdatedMessage
+        case CBOX_UTF8_ERROR.rawValue:
+            self = .CryptoboxUTF8Error
+        case CBOX_NUL_ERROR.rawValue:
+            self = .CryptoboxNulError
+        case CBOX_ENCODE_ERROR.rawValue:
+            self = .CryptoboxEncodeError
+        case CBOX_IDENTITY_ERROR.rawValue:
+            self = .CryptoboxIdentityError
+        case CBOX_PREKEY_NOT_FOUND.rawValue:
+            self = .CryptoboxPrekeyNotFound
+        case CBOX_PANIC.rawValue:
+            self = .CryptoboxPanic
+            
+        default:
+            return nil
+        }
+    }
+}

--- a/Cryptobox/EncryptionSessionsDirectory.swift
+++ b/Cryptobox/EncryptionSessionsDirectory.swift
@@ -132,7 +132,7 @@ extension EncryptionSessionsDirectory {
                                                    &cbsession.ptr
         )
         guard result == CBOX_SUCCESS else {
-            throw result
+            throw CryptoboxError(rawValue: result.rawValue)!
         }
         let session = EncryptionSession(id: clientId,
                                         session: cbsession,
@@ -155,7 +155,7 @@ extension EncryptionSessionsDirectory {
                                                     &cbsession.ptr,
                                                     &plainTextBacking)
         guard result == CBOX_SUCCESS else {
-            throw result
+            throw CryptoboxError(rawValue: result.rawValue)!
         }
         let plainText = NSData.moveFromCBoxVector(plainTextBacking)
         let session = EncryptionSession(id: clientId,

--- a/CryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/CryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -194,8 +194,8 @@ extension EncryptionSessionsDirectoryTests {
             _ = try statusAlice.createClientSession(Person.Bob.clientId, base64PreKeyString: "aabb")
             XCTFail("should have failed to use prekey")
         }
-        catch let err as CBoxResult {
-            XCTAssertEqual(err, CBOX_DECODE_ERROR)
+        catch let err as CryptoboxError {
+            XCTAssertEqual(err, CryptoboxError.CryptoboxDecodeError)
         } catch {
             XCTFail("should have thrown a CBoxResult")
         }


### PR DESCRIPTION
**What's in this PR**
CBoxResult being a pure swift struct (autogenerated from C), it doesn't translate to NSError in Objc when thrown.
To fix that, we need to create a `@objc` ErrorType that we would throw. 