### PR TITLE
Reimplement string splitting function for better performances

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wireapp/wire-ios-system" "16.0.0"
+github "wireapp/wire-ios-system" "16.0.6"

--- a/Cryptobox/EncryptionSession+Debugging.swift
+++ b/Cryptobox/EncryptionSession+Debugging.swift
@@ -49,14 +49,15 @@ extension String {
     
     /// Splits a string in array of strings each with a length not exceding the given size
     func split(bySize size: Int) -> [String] {
-        var original = self
-        var finalArray : [String] = []
-        while !original.isEmpty {
-            let chunkLength = min(size, original.characters.count)
-            let chunkIndex = original.index(original.startIndex, offsetBy: chunkLength)
-            finalArray.append(original.substring(to: chunkIndex))
-            original = original.substring(from: chunkIndex)
+        var charsLeft = self.characters.count
+        let chunks = Int(ceil(Double(charsLeft) / Double(size)))
+        var stringIndex = self.startIndex
+        return (0..<chunks).map { _ in
+            let endIndex = self.index(stringIndex, offsetBy: min(size, charsLeft))
+            let range = stringIndex..<endIndex
+            charsLeft -= size
+            stringIndex = endIndex
+            return self.substring(with: range)
         }
-        return finalArray
     }
 }

--- a/Cryptobox/EncryptionSessionsDirectory.swift
+++ b/Cryptobox/EncryptionSessionsDirectory.swift
@@ -441,7 +441,9 @@ extension EncryptionSession {
     fileprivate func decrypt(_ cypher: Data) throws -> Data {
         var vectorBacking : OpaquePointer? = nil
 
-        zmLog.debug("Decrypting with session \(self.id): \(cypher.base64Dump)")
+        zmLog.ifDebug {
+            zmLog.debug("Decrypting with session \(self.id): \(cypher.base64Dump)")
+        }
         let result = cypher.withUnsafeBytes { (cypherPointer: UnsafePointer<UInt8>) -> CBoxResult in
             cbox_decrypt(self.implementation.ptr,
                          cypherPointer,
@@ -474,7 +476,9 @@ extension EncryptionSession {
         }
         self.hasChanges = true
         let data = Data.moveFromCBoxVector(vectorBacking)!
-        zmLog.debug("Encrypted with session \(self.id) to cypher text:\(data.base64Dump)")
+        zmLog.ifDebug {
+            zmLog.debug("Encrypted with session \(self.id) to cypher text:\(data.base64Dump)")
+        }
         return data
     }
 }

--- a/CryptoboxTests/EncryptionDebugTests.swift
+++ b/CryptoboxTests/EncryptionDebugTests.swift
@@ -44,4 +44,21 @@ class EncryptionDebugTests : XCTestCase {
         let joined = dump.components(separatedBy: "\n").joined(separator: "")
         XCTAssertEqual(joined, "--START--\(data.base64EncodedString())--END--")
     }
+    
+    func testThatItDumpBase64_long() {
+        
+        // GIVEN
+        var seed = "12345678"
+        (0..<15).forEach { _ in
+            seed += seed
+        }
+        let data = seed.data(using: .utf8)!
+        
+        // WHEN
+        let dump = data.base64Dump
+        
+        // THEN
+        let joined = dump.components(separatedBy: "\n").joined(separator: "")
+        XCTAssertEqual(joined, "--START--\(data.base64EncodedString())--END--")
+    }
 }

--- a/CryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/CryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -111,7 +111,7 @@ extension EncryptionSessionsDirectoryTests {
     /// Checks if a message can be encrypted and successfully decrypted
     /// by the other person
     /// - note: it does commit the session cache
-    @discardableResult func checkThatAMessageCanBeSent(_ from: Person, saveReceiverCache : Bool = true) -> Bool {
+    @discardableResult func checkThatAMessageCanBeSent(_ from: Person, saveReceiverCache : Bool = true, data: Data? = nil) -> Bool {
         let clientId1 = from.clientId
         let clientId2 = from.other.clientId
         
@@ -125,7 +125,7 @@ extension EncryptionSessionsDirectoryTests {
             }
         }
         
-        let plainText = "निर्वाण".data(using: String.Encoding.utf8)!
+        let plainText = data ?? "निर्वाण".data(using: String.Encoding.utf8)!
         do {
             let cypherText = try status1?.encrypt(plainText, recipientClientId: clientId2)
             let decoded = try status2?.decrypt(cypherText!, senderClientId: clientId1)


### PR DESCRIPTION
# Reason for this pull request
The `String.split(bySize:)` was extremely slow. It was relaying on a loop that was creating a substring of the original string without the removed part (which could potentially result in copying a huge string)
 
# Changes
- Create a substring only as long as the chunk and keep a rolling index in the string to track the start of the substring. This speed up the function significantly. 
- Also changed the logs to avoid generating log message when not needed (log disabled).

