### PR TITLE
Add function to migrate sessions to a new ID

### DIFF
--- a/Cryptobox/EncryptionSession+Debugging.swift
+++ b/Cryptobox/EncryptionSession+Debugging.swift
@@ -25,8 +25,7 @@ extension EncryptionSession {
     /// To be used for debugging purposes.
     func dumpSessionContent(function: String = #function) {
         zmLog.ifDebug {
-            let path = self.cryptoboxPath.appendingPathComponent("sessions").appendingPathComponent(self.id)
-            guard let data = try? Data(contentsOf: path) else {
+            guard let data = try? Data(contentsOf: self.path) else {
                 zmLog.debug("Failed to dump content of session \(self.id)")
                 return
             }

--- a/CryptoboxTests/EncryptionContextTests.swift
+++ b/CryptoboxTests/EncryptionContextTests.swift
@@ -164,11 +164,11 @@ class EncryptionContextTests: XCTestCase {
             try! context1.createClientSession(hardcodedClientId, base64PreKeyString: hardcodedPrekey)
             
             mainContext.perform { context2 in
-                _ = try! context2.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, recipientClientId: hardcodedClientId)
+                _ = try! context2.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, recipientIdentifier: hardcodedClientId)
                 
             }
             
-            _ = try! context1.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, recipientClientId: hardcodedClientId)
+            _ = try! context1.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, recipientIdentifier: hardcodedClientId)
         }
         
         // THEN 

--- a/CryptoboxTests/ObjCInteroperabilityMatcher.h
+++ b/CryptoboxTests/ObjCInteroperabilityMatcher.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ObjCInteroperabilityMatcher : NSObject
 
 - (BOOL)returnsCorrectErrorCodeDecryptingCypher:(NSData *)cypher
-                                 senderClientId:(NSString *)senderClientId
+                               senderIdentifier:(NSString *)senderIdentifier
                                   expectedError:(CryptoboxError)error
                                sessionDirectory:(EncryptionSessionsDirectory *)sessionDirectory;
 

--- a/CryptoboxTests/ObjCInteroperabilityMatcher.m
+++ b/CryptoboxTests/ObjCInteroperabilityMatcher.m
@@ -21,12 +21,12 @@
 @implementation ObjCInteroperabilityMatcher
 
 - (BOOL)returnsCorrectErrorCodeDecryptingCypher:(NSData *)cypher
-                                 senderClientId:(NSString *)senderClientId
+                               senderIdentifier:(NSString *)senderIdentifier
                                   expectedError:(CryptoboxError)error
                                sessionDirectory:(EncryptionSessionsDirectory *)sessionDirectory
 {
     NSError *actualError;
-    [sessionDirectory decrypt:cypher senderClientId:senderClientId error:&actualError];
+    [sessionDirectory decrypt:cypher senderIdentifier:senderIdentifier error:&actualError];
 
     return actualError.code == error;
 }


### PR DESCRIPTION
# Reason for this pull request
Using the client ID as session identifier does not guarantee uniqueness, as client IDs are a small domain, and there is a risk of collision, that would result in trashed sessions. We should use a combination of user ID (UUIDs) and cliend IDs. In order to keep existing sessions when switching to the new identifier, we need to migrate session files. This PR introduces a migration function.
