### PR TITLE
Add file header before encrypted data containing metadata

### DIFF
--- a/WireCryptobox/ChaCha20Encryption.swift
+++ b/WireCryptobox/ChaCha20Encryption.swift
@@ -153,8 +153,8 @@ public final class ChaCha20Encryption {
                                         uuidAsBytes.map(Int8.init),
                                         UInt64(uuidAsBytes.count),
                                         salt,
-                                        UInt64(crypto_pwhash_OPSLIMIT_INTERACTIVE),
-                                        Int(crypto_pwhash_MEMLIMIT_INTERACTIVE),
+                                        UInt64(crypto_pwhash_argon2i_OPSLIMIT_INTERACTIVE),
+                                        Int(crypto_pwhash_argon2i_MEMLIMIT_INTERACTIVE),
                                         crypto_pwhash_argon2i_ALG_ARGON2I13) == 0 else {
                 throw EncryptionError.keyGenerationFailed
             }
@@ -191,8 +191,8 @@ public final class ChaCha20Encryption {
                                         UInt64(crypto_secretstream_xchacha20poly1305_KEYBYTES),
                                         password, UInt64(password.lengthOfBytes(using: .utf8)),
                                         salt,
-                                        UInt64(crypto_pwhash_OPSLIMIT_MODERATE),
-                                        Int(crypto_pwhash_MEMLIMIT_MODERATE),
+                                        UInt64(crypto_pwhash_argon2i_OPSLIMIT_MODERATE),
+                                        Int(crypto_pwhash_argon2i_MEMLIMIT_MODERATE),
                                         crypto_pwhash_argon2i_ALG_ARGON2I13) == 0 else {
                 throw EncryptionError.keyGenerationFailed
             }

--- a/WireCryptobox/ChaCha20Encryption.swift
+++ b/WireCryptobox/ChaCha20Encryption.swift
@@ -153,7 +153,7 @@ public final class ChaCha20Encryption {
                                         uuidAsBytes.map(Int8.init),
                                         UInt64(uuidAsBytes.count),
                                         salt,
-                                        1,
+                                        UInt64(crypto_pwhash_OPSLIMIT_INTERACTIVE),
                                         Int(crypto_pwhash_MEMLIMIT_INTERACTIVE),
                                         crypto_pwhash_argon2i_ALG_ARGON2I13) == 0 else {
                 throw EncryptionError.keyGenerationFailed

--- a/WireCryptobox/ChaCha20Encryption.swift
+++ b/WireCryptobox/ChaCha20Encryption.swift
@@ -64,15 +64,15 @@ public final class ChaCha20Encryption {
                 })
             }
             
-            static func partition(buffer: Array<UInt8>, _ into: (_ partition: ArraySlice<UInt8>, _ part: Field) throws -> Void) throws {
+            static func partition(buffer: Array<UInt8>, _ into: (_ partition: ArraySlice<UInt8>, _ field: Field) throws -> Void) throws {
                 guard buffer.count == Field.sizeOfAllFields else {
                     throw EncryptionError.malformedHeader
                 }
                 
                 var index = 0
-                for part in layout {
-                    let upperBound = index + part.rawValue
-                    try into(buffer[index..<upperBound], part)
+                for field in layout {
+                    let upperBound = index + field.rawValue
+                    try into(buffer[index..<upperBound], field)
                     index = upperBound
                 }
             }
@@ -90,8 +90,8 @@ public final class ChaCha20Encryption {
             var salt: Array<UInt8> = Array<UInt8>(repeating: 0, count: Field.salt.rawValue)
             var hash: Array<UInt8> = Array<UInt8>(repeating: 0, count: Field.uuidHash.rawValue)
             
-            try Field.partition(buffer: buffer) { (partition, part) in
-                switch part {
+            try Field.partition(buffer: buffer) { (partition, field) in
+                switch field {
                 case .platform:
                     guard Array(partition) == [UInt8](Header.platform) else {
                         throw EncryptionError.malformedHeader

--- a/WireCryptobox/ChaCha20Encryption.swift
+++ b/WireCryptobox/ChaCha20Encryption.swift
@@ -21,9 +21,11 @@ import Foundation
 public final class ChaCha20Encryption {
     
     private static let bufferSize = 1024 * 1024
+    private static let keyGenerationIterations: UInt64 = 6
+    private static let keyGenerationMemoryLimit: Int = 134217728
     
     public enum EncryptionError: Error {
-        /// Couldn't read  corrupt message header
+        /// Couldn't read corrupt message header
         case malformedHeader
         /// Encryption failed
         case encryptionFailed
@@ -35,52 +37,176 @@ public final class ChaCha20Encryption {
         case writeError(Error)
         /// Stream end was reached while expecting more data
         case unexpectedStreamEnd
+        /// Failure generating a key.
+        case keyGenerationFailed
+        /// Passphrase UUID is different from what was used during encryption
+        case mismatchingUUID
+        /// File was encrypted on a unsupported platform
+        case unsupportedPlatform
+        /// Failure initializing sodium
+        case failureInitializingSodium
         /// Unknown error
         case unknown
     }
     
-    /// ChaCha20 Key
-    public struct Key {
-        fileprivate static let salt = "WVBPkDGfcijYPCcduAnkxBdBuMNbRQkB"
-        fileprivate let buffer: Array<UInt8>
+    internal enum Platform: String {
+        case iOS = "WBUI"
+        case Android = "WBUA"
+        case Web = "WBUD"
         
-        /// Generate a key
-        public init() {
-            var buffer = Array<UInt8>(repeating: 0, count: Int(crypto_secretstream_xchacha20poly1305_KEYBYTES))
-            crypto_secretstream_xchacha20poly1305_keygen(&buffer)
+        init?(buffer: Array<UInt8>) {
+            guard buffer.count == 4, let platform = String(bytes: buffer, encoding: .ascii) else {
+                return nil
+            }
+            
+            self.init(rawValue: platform)
+        }
+        
+        var bytes: Data {
+            return rawValue.data(using: .ascii)!
+        }
+    }
+    
+    internal struct Header {
+        
+        public static var size: Int = 55
+        
+        static let platformRange = (0..<4)
+        static let versionRange = (5..<7)
+        static let saltRange = (7..<23)
+        static let hashRange = (23..<55)
+        
+        let buffer: Array<UInt8>
+        
+        var salt: ArraySlice<UInt8> {
+            return buffer[Header.saltRange]
+        }
+        var uuidHash: ArraySlice<UInt8> {
+            return buffer[Header.hashRange]
+        }
+        var platform: Platform
+        var version: UInt16
+        
+        init(buffer: Array<UInt8>) throws {
+            
+            guard buffer.count == Header.size else {
+                throw EncryptionError.malformedHeader
+            }
+            
+            guard let platform = Platform(buffer: Array(buffer[Header.platformRange])) else  {
+                throw EncryptionError.malformedHeader
+            }
+            
+            self.platform = platform
+            self.version = UInt16(bigEndian: Data(bytes: Array(buffer[Header.versionRange])).withUnsafeBytes { $0.pointee })
             self.buffer = buffer
         }
+        
+        init(uuid: UUID, platform: Platform = .iOS) throws {
+            var buffer = Array<UInt8>()
+            
+            buffer.append(contentsOf: [UInt8](platform.bytes))
+            buffer.append(0)
+            buffer.append(contentsOf: [0, 1])
+            
+            var salt = Array<UInt8>(repeating: 0, count: Int(crypto_pwhash_argon2i_SALTBYTES))
+            randombytes(&salt, UInt64(crypto_pwhash_argon2i_SALTBYTES))
+            buffer.append(contentsOf: salt)
+            buffer.append(contentsOf: try Header.hash(uuid: uuid, salt: salt))
+            
+            self.version = 1
+            self.platform = platform
+            self.buffer = buffer
+        }
+        
+        internal func deriveKey(from passphrase: Passphrase) throws -> Key {
+            let salt = Array(self.salt)
+            
+            guard try Header.hash(uuid: passphrase.uuid, salt: salt) == Array(uuidHash) else {
+                throw EncryptionError.mismatchingUUID
+            }
+            
+            return try Key(password: passphrase.password, salt: salt)
+        }
+        
+        fileprivate static func hash(uuid: UUID, salt: Array<UInt8>) throws -> Array<UInt8> {
+            var uuidAsBytes = Array<UInt8>(repeating: 0, count: 128)
+            (uuid as NSUUID).getBytes(&uuidAsBytes)
+            
+            let hashSize = 32
+            var hash = Array<UInt8>(repeating: 0, count: hashSize)
+            guard crypto_pwhash_argon2i(&hash,
+                                        UInt64(hashSize),
+                                        uuidAsBytes.map(Int8.init),
+                                        UInt64(uuidAsBytes.count),
+                                        salt,
+                                        keyGenerationIterations,
+                                        keyGenerationMemoryLimit,
+                                        crypto_pwhash_argon2i_ALG_ARGON2I13) == 0 else {
+                throw EncryptionError.keyGenerationFailed
+            }
+            
+            return hash
+        }
+        
+    }
+    
+    /// Passphrase for encrypting/decrypting using ChaCha20.
+    public struct Passphrase {
+        fileprivate let uuid: UUID
+        fileprivate let password: String
+        
+        public init(password: String, uuid: UUID) {
+            self.password = password
+            self.uuid = uuid
+        }
+    }
+    
+    /// ChaCha20 Key
+    internal struct Key {
+        
+        fileprivate let buffer: Array<UInt8>
         
         /// Generate a key from a passphrase.
         /// - passphrase: string which is used to derive the key
         ///
         /// NOTE: this can fail if the system runs out of memory.
-        public init?(passphrase: String) {
+        public init(password: String, salt: Array<UInt8>) throws {
             var buffer = Array<UInt8>(repeating: 0, count: Int(crypto_secretstream_xchacha20poly1305_KEYBYTES))
             
-            guard crypto_pwhash(&buffer,
-                                UInt64(crypto_secretstream_xchacha20poly1305_KEYBYTES),
-                                passphrase,
-                                UInt64(passphrase.lengthOfBytes(using: .utf8)),
-                                Key.salt,
-                                UInt64(crypto_pwhash_OPSLIMIT_MODERATE),
-                                Int(crypto_pwhash_MEMLIMIT_MODERATE),
-                                crypto_pwhash_ALG_DEFAULT) == 0 else {
-                                    return nil
+            guard crypto_pwhash_argon2i(&buffer,
+                                        UInt64(crypto_secretstream_xchacha20poly1305_KEYBYTES),
+                                        password, UInt64(password.lengthOfBytes(using: .utf8)),
+                                        salt,
+                                        keyGenerationIterations,
+                                        keyGenerationMemoryLimit,
+                                        crypto_pwhash_argon2i_ALG_ARGON2I13) == 0 else {
+                throw EncryptionError.keyGenerationFailed
             }
             
             self.buffer = buffer
+        }
+        
+    }
+    
+    fileprivate static func initializeSodium() throws {
+        guard sodium_init() >= 0 else {
+            throw EncryptionError.failureInitializingSodium
         }
     }
     
     /// Encrypts an input stream using xChaCha20
     /// - input: plaintext input stream
     /// - output: decrypted output stream
+    /// - passphrase: passphrase
     ///
     /// - Throws: Stream errors.
     /// - Returns: number of encrypted bytes written to the output stream
     @discardableResult
-    public static func encrypt(input: InputStream, output: OutputStream, key: Key) throws -> Int {
+    public static func encrypt(input: InputStream, output: OutputStream, passphrase: Passphrase) throws -> Int {
+        
+        try initializeSodium()
+        
         input.open()
         output.open()
         
@@ -88,11 +214,26 @@ public final class ChaCha20Encryption {
             input.close()
             output.close()
         }
+        
+        var totalBytesWritten = 0
+        var bytesWritten = -1
+        var bytesRead = -1
+        var bytesReadReadAhead = -1
+        
+        let fileHeader = try Header(uuid: passphrase.uuid)
+        let key = try fileHeader.deriveKey(from: passphrase)
+    
+        bytesWritten = output.write(fileHeader.buffer, maxLength: fileHeader.buffer.count)
+        totalBytesWritten += bytesWritten
+        
+        guard bytesWritten > 0 else {
+            throw EncryptionError.writeError(output.streamError ?? EncryptionError.unexpectedStreamEnd)
+        }
 
-        var header = Array<UInt8>(repeating: 0, count: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES))
+        var chachaHeader = Array<UInt8>(repeating: 0, count: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES))
         var state = crypto_secretstream_xchacha20poly1305_state()
         
-        guard crypto_secretstream_xchacha20poly1305_init_push(&state, &header, key.buffer) == 0 else {
+        guard crypto_secretstream_xchacha20poly1305_init_push(&state, &chachaHeader, key.buffer) == 0 else {
             throw EncryptionError.encryptionFailed
         }
         
@@ -102,12 +243,7 @@ public final class ChaCha20Encryption {
         let cipherBufferSize = bufferSize + Int(crypto_secretstream_xchacha20poly1305_ABYTES)
         var cipherBuffer = Array<UInt8>(repeating: 0, count: cipherBufferSize)
         
-        var totalBytesWritten = 0
-        var bytesWritten = -1
-        var bytesRead = -1
-        var bytesReadReadAhead = -1
-        
-        bytesWritten = output.write(header, maxLength: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES))
+        bytesWritten = output.write(chachaHeader, maxLength: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES))
         totalBytesWritten += bytesWritten
         
         guard bytesWritten > 0 else {
@@ -158,11 +294,15 @@ public final class ChaCha20Encryption {
     /// Decrypts an input stream using xChaCha20
     /// - input: encrypted input stream
     /// - output: plaintext output stream
+    /// - passphrase: passphrase
     ///
     /// - Throws: Stream errors and `malformedHeader` or `decryptionFailed` if decryption fails.
     /// - Returns: number of decrypted bytes written to the output stream.
     @discardableResult
-    public static func decrypt(input: InputStream, output: OutputStream, key: Key) throws -> Int {
+    public static func decrypt(input: InputStream, output: OutputStream, passphrase: Passphrase) throws -> Int {
+        
+        try initializeSodium()
+        
         input.open()
         output.open()
         
@@ -175,14 +315,27 @@ public final class ChaCha20Encryption {
         var bytesWritten = -1
         var bytesRead = -1
         
-        var state = crypto_secretstream_xchacha20poly1305_state()
-        var header = Array<UInt8>(repeating: 0, count: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES))
+        var fileHeaderBuffer = Array<UInt8>(repeating: 0, count: Int(Header.size))
         
-        guard input.read(&header, maxLength: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES)) > 0  else {
+        guard input.read(&fileHeaderBuffer, maxLength: Header.size) > 0  else {
+            throw EncryptionError.readError(input.streamError ?? EncryptionError.unexpectedStreamEnd)
+        }
+        
+        let fileHeader = try Header(buffer: fileHeaderBuffer)
+        
+        guard fileHeader.platform == .iOS, fileHeader.version == 1 else {
+            throw EncryptionError.unsupportedPlatform
+        }
+        
+        let key = try fileHeader.deriveKey(from: passphrase)
+        var state = crypto_secretstream_xchacha20poly1305_state()
+        var chachaHeader = Array<UInt8>(repeating: 0, count: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES))
+        
+        guard input.read(&chachaHeader, maxLength: Int(crypto_secretstream_xchacha20poly1305_HEADERBYTES)) > 0  else {
             throw EncryptionError.readError(input.streamError ?? EncryptionError.unexpectedStreamEnd)
         }
 
-        guard crypto_secretstream_xchacha20poly1305_init_pull(&state, header, key.buffer) == 0 else {
+        guard crypto_secretstream_xchacha20poly1305_init_pull(&state, chachaHeader, key.buffer) == 0 else {
             throw EncryptionError.malformedHeader
         }
         

--- a/WireCryptobox/ChaCha20Encryption.swift
+++ b/WireCryptobox/ChaCha20Encryption.swift
@@ -118,7 +118,7 @@ public final class ChaCha20Encryption {
             var buffer = Array<UInt8>()
             var version = Header.version.bigEndian
             var salt = Array<UInt8>(repeating: 0, count: Int(crypto_pwhash_argon2i_SALTBYTES))
-            randombytes(&salt, UInt64(crypto_pwhash_argon2i_SALTBYTES))
+            randombytes_buf(&salt, Int(UInt64(crypto_pwhash_argon2i_SALTBYTES)))
             let uuidHash = try Header.hash(uuid: uuid, salt: salt)
             
             buffer.append(contentsOf: [UInt8](Header.platform))

--- a/WireCryptoboxTests/ChaCha20EncryptionTests.swift
+++ b/WireCryptoboxTests/ChaCha20EncryptionTests.swift
@@ -17,7 +17,75 @@
 // 
 
 import XCTest
-import WireCryptobox
+@testable import WireCryptobox
+
+class ChaCha20FileHeaderTests: XCTestCase {
+    
+    func testThatFileHeaderIsWrittenWithCorrectMemoryLayout() throws {
+        // given
+        let uuid = UUID()
+        
+        // when
+        let header = try ChaCha20Encryption.Header(uuid: uuid, platform: .iOS)
+        
+        // then
+        XCTAssertEqual(header.buffer.count, ChaCha20Encryption.Header.size)
+        XCTAssertEqual(Array(header.buffer[ChaCha20Encryption.Header.platformRange]), [UInt8](ChaCha20Encryption.Platform.iOS.bytes))
+        XCTAssertEqual(Array(header.buffer[ChaCha20Encryption.Header.versionRange]), [0, 1])
+    }
+    
+    func testThatFileHeaderCanBeReadFromBuffer() throws {
+        // given
+        let buffer = Data(base64Encoded: "V0JVSQAAAQ8CgQ/ikb7pIkWDhhDkY7uMxemLjGnPNJ2ohITEekzYAzAxygPF36PpKw9HXrGZWg==")!
+        
+        // when
+        let header = try ChaCha20Encryption.Header(buffer: [UInt8](buffer))
+        
+        var foo = header.buffer
+        foo[3] = 65
+    
+        // then
+        XCTAssertEqual(header.platform, .iOS)
+        XCTAssertEqual(header.version, 1)
+        XCTAssertEqual(header.salt, [15, 2, 129, 15 ,226 ,145, 190, 233, 34, 69, 131, 134, 16, 228, 99, 187])
+        XCTAssertEqual(header.uuidHash, [140, 197, 233, 139, 140, 105, 207, 52, 157, 168, 132, 132, 196, 122, 76, 216, 3, 48, 49, 202, 3, 197, 223, 163, 233, 43, 15, 71, 94, 177, 153, 90 ])
+    }
+    
+    func testThatParsingHeaderWithWrongSizeThrowsAnError() {
+        // given
+        let buffer = [UInt8]([0,1,3])
+        
+        // when
+        do {
+            _ = try ChaCha20Encryption.Header(buffer: buffer)
+        } catch ChaCha20Encryption.EncryptionError.malformedHeader {
+            // success
+            return
+        } catch {
+            XCTFail("Unexpected error")
+        }
+        
+        XCTFail("Expected error")
+    }
+    
+    func testThatParsingHeaderWithUnknownPlatformThrowsAnError() {
+        // given
+        let buffer = [UInt8](Data(base64Encoded: "QldVSQAAAQ8CgQ/ikb7pIkWDhhDkY7uMxemLjGnPNJ2ohITEekzYAzAxygPF36PpKw9HXrGZWg==")!)
+        
+        // when
+        do {
+            _ = try ChaCha20Encryption.Header(buffer: buffer)
+        } catch ChaCha20Encryption.EncryptionError.malformedHeader {
+            // success
+            return
+        } catch {
+            XCTFail("Unexpected error")
+        }
+        
+        XCTFail("Expected error")
+    }
+    
+}
 
 class ChaCha20EncryptionTests: XCTestCase {
     
@@ -45,40 +113,40 @@ class ChaCha20EncryptionTests: XCTestCase {
         return directoryURL.appendingPathComponent(UUID().uuidString)
     }
     
-    func encrypt(_ message: Data, key: ChaCha20Encryption.Key) throws -> Data {
+    func encrypt(_ message: Data, passphrase: ChaCha20Encryption.Passphrase) throws -> Data {
         let inputStream = InputStream(data: message)
         var outputBuffer = Array<UInt8>(repeating: 0, count: 256)
         let outputStream = OutputStream(toBuffer: &outputBuffer, capacity: 256)
         
-        let bytesWritten = try ChaCha20Encryption.encrypt(input: inputStream, output: outputStream, key: key)
+        let bytesWritten = try ChaCha20Encryption.encrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         
         return Data(bytes: outputBuffer.prefix(bytesWritten))
     }
     
-    func decrypt(_ chipherMessage: Data, key: ChaCha20Encryption.Key) throws -> Data {
+    func decrypt(_ chipherMessage: Data, passphrase: ChaCha20Encryption.Passphrase) throws -> Data {
         var outputBuffer = Array<UInt8>(repeating: 0, count: 256)
         let outputStream = OutputStream(toBuffer: &outputBuffer, capacity: 256)
         let inputStream = InputStream(data: chipherMessage)
-        let decryptedBytes = try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, key: key)
+        let decryptedBytes = try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         
         return Data(bytes: outputBuffer.prefix(decryptedBytes))
     }
     
-    func encryptToURL(_ message: Data, key: ChaCha20Encryption.Key) throws -> URL {
+    func encryptToURL(_ message: Data, passphrase: ChaCha20Encryption.Passphrase) throws -> URL {
         let inputURL = createTemporaryURL()
         let outputURL = createTemporaryURL()
         try message.write(to: inputURL)
         let inputStream = InputStream(url: inputURL)!
         let outputStream = OutputStream(url: outputURL, append: false)!
-        try ChaCha20Encryption.encrypt(input: inputStream, output: outputStream, key: key)
+        try ChaCha20Encryption.encrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         return outputURL
     }
     
-    func decryptFromURL(_ url: URL, key: ChaCha20Encryption.Key, file: StaticString = #file, line: UInt = #line) throws -> Data {
+    func decryptFromURL(_ url: URL, passphrase: ChaCha20Encryption.Passphrase, file: StaticString = #file, line: UInt = #line) throws -> Data {
         let outputURL = createTemporaryURL()
         let outputStream = OutputStream(url: outputURL, append: false)!
         let inputStream = InputStream(url: url)!
-        let decryptedBytes = try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, key: key)
+        let decryptedBytes = try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         XCTAssertGreaterThan(decryptedBytes, 0, file: file, line: line)
         return try Data(contentsOf: outputURL)
     }
@@ -88,63 +156,63 @@ class ChaCha20EncryptionTests: XCTestCase {
     func testThatEncryptionAndDecryptionWorks() throws {
         
         // given
-        let key = ChaCha20Encryption.Key()
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID())
         let message = "123456789"
         let messageData =  message.data(using: .utf8)!
         
         // when
-        let encryptedMessage = try encrypt(messageData, key: key)
-        let decryptedMessage = try decrypt(encryptedMessage, key: key)
+        let encryptedMessage = try encrypt(messageData, passphrase: passphrase)
+        let decryptedMessage = try decrypt(encryptedMessage, passphrase: passphrase)
         
         // then
         XCTAssertEqual(decryptedMessage, messageData)
     }
     
-    func testThatEncryptionAndDecryptionWorksWithPassphrase() throws {
-        
-        // given
-        let passphrase = "helloworld"
-        let message = "123456789"
-        let messageData =  message.data(using: .utf8)!
-        
-        // when
-        let encryptedMessage = try encrypt(messageData, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
-        let decryptedMessage = try decrypt(encryptedMessage, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
-        
-        // then
-        XCTAssertEqual(decryptedMessage, messageData)
-    }
+//    func testThatEncryptionAndDecryptionWorksWithPassphrase() throws {
+//
+//        // given
+//        let passphrase = "helloworld"
+//        let message = "123456789"
+//        let messageData =  message.data(using: .utf8)!
+//
+//        // when
+//        let encryptedMessage = try encrypt(messageData, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
+//        let decryptedMessage = try decrypt(encryptedMessage, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
+//
+//        // then
+//        XCTAssertEqual(decryptedMessage, messageData)
+//    }
     
     func testThatEncryptionAndDecryptionWorks_ToDisk() throws {
         
         // given
-        let key = ChaCha20Encryption.Key()
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID())
         let message = "123456789"
         let messageData =  message.data(using: .utf8)!
         
         // when
-        let encryptedDataURL = try encryptToURL(messageData, key: key)
-        let decryptedMessage = try decryptFromURL(encryptedDataURL, key: key)
+        let encryptedDataURL = try encryptToURL(messageData, passphrase: passphrase)
+        let decryptedMessage = try decryptFromURL(encryptedDataURL, passphrase: passphrase)
         
         // then
         XCTAssertEqual(decryptedMessage, messageData)
     }
     
-    func testThatEncryptionAndDecryptionWorksWithPassphrase_ToDisk() throws {
-        
-        // given
-        let passphrase = "helloworld"
-        let message = "123456789"
-        let messageData =  message.data(using: .utf8)!
-        
-        // when
-        let encryptedDataURL = try encryptToURL(messageData, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
-        let decryptedMessage = try decryptFromURL(encryptedDataURL, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
-        
-        // then
-        XCTAssertEqual(decryptedMessage, messageData)
-    }
-    
+//    func testThatEncryptionAndDecryptionWorksWithPassphrase_ToDisk() throws {
+//
+//        // given
+//        let passphrase = "helloworld"
+//        let message = "123456789"
+//        let messageData =  message.data(using: .utf8)!
+//
+//        // when
+//        let encryptedDataURL = try encryptToURL(messageData, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
+//        let decryptedMessage = try decryptFromURL(encryptedDataURL, key: ChaCha20Encryption.Key(passphrase: passphrase)!)
+//
+//        // then
+//        XCTAssertEqual(decryptedMessage, messageData)
+//    }
+//
     func testThatItThrowsWriteErrorWhenOutputStreamFailsWhileEncrypting() throws {
         
         // given
@@ -153,11 +221,11 @@ class ChaCha20EncryptionTests: XCTestCase {
         let inputStream = InputStream(data: messageData)
         var outputBuffer = Array<UInt8>(repeating: 0, count: 1)
         let outputStream = OutputStream(toBuffer: &outputBuffer, capacity: 1)
-        let key = ChaCha20Encryption.Key()
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID())
         
         // then when
         do {
-            try ChaCha20Encryption.encrypt(input: inputStream, output: outputStream, key: key)
+            try ChaCha20Encryption.encrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         } catch ChaCha20Encryption.EncryptionError.writeError {
             return // success
         } catch {
@@ -170,7 +238,7 @@ class ChaCha20EncryptionTests: XCTestCase {
     func testThatItThrowsReadErrorOnEmptyData() {
         
         // given
-        let key = ChaCha20Encryption.Key()
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID())
         let malformedMessageData =  "".data(using: .utf8)!
         var outputBuffer = Array<UInt8>(repeating: 0, count: 256)
         let outputStream = OutputStream(toBuffer: &outputBuffer, capacity: 256)
@@ -178,7 +246,7 @@ class ChaCha20EncryptionTests: XCTestCase {
         
         // then when
         do {
-            try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, key: key)
+            try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         } catch ChaCha20Encryption.EncryptionError.readError {
             return // success
         } catch {
@@ -188,10 +256,10 @@ class ChaCha20EncryptionTests: XCTestCase {
         XCTFail()
     }
     
-    func testThatItThrowsDecryptionFailedOnBadData() {
+    func testThatItThrowsMalformedHeaderOnBadData() {
         
         // given
-        let key = ChaCha20Encryption.Key()
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID())
         let malformedMessageData =  "malformed12345678901234567890123456789012345678901234567890".data(using: .utf8)!
         var outputBuffer = Array<UInt8>(repeating: 0, count: 256)
         let outputStream = OutputStream(toBuffer: &outputBuffer, capacity: 256)
@@ -199,8 +267,8 @@ class ChaCha20EncryptionTests: XCTestCase {
         
         // then when
         do {
-            try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, key: key)
-        } catch ChaCha20Encryption.EncryptionError.decryptionFailed {
+            try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, passphrase: passphrase)
+        } catch ChaCha20Encryption.EncryptionError.malformedHeader {
             return // success
         } catch {
             XCTFail()
@@ -212,9 +280,9 @@ class ChaCha20EncryptionTests: XCTestCase {
     func testThatItThrowsWriteErrorWhenOutputStreamFailsWhileDecrypting() {
         
         // given
-        let key = ChaCha20Encryption.Key()
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID())
         let message = "123456789".data(using: .utf8)!
-        let encryptedData = try! encrypt(message, key: key)
+        let encryptedData = try! encrypt(message, passphrase: passphrase)
         
         let inputStream = InputStream(data: encryptedData)
         var outputBuffer = Array<UInt8>(repeating: 0, count: 1)
@@ -222,8 +290,69 @@ class ChaCha20EncryptionTests: XCTestCase {
         
         // then when
         do {
-            try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, key: key)
+            try ChaCha20Encryption.decrypt(input: inputStream, output: outputStream, passphrase: passphrase)
         } catch ChaCha20Encryption.EncryptionError.writeError {
+            return // success
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testThatItThrowsMismatchingUUIDWhenDecryptingWithADifferentUUID() {
+        
+        // given
+        let uuid1 = UUID()
+        let uuid2 = UUID()
+        let password = "1235678"
+        let message = "123456789".data(using: .utf8)!
+        
+        // then when
+        do {
+            let encryptedMessage = try encrypt(message, passphrase: ChaCha20Encryption.Passphrase(password: password, uuid: uuid1))
+            _ = try decrypt(encryptedMessage, passphrase: ChaCha20Encryption.Passphrase(password: password, uuid: uuid2))
+        } catch ChaCha20Encryption.EncryptionError.mismatchingUUID {
+            return // success
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testThatItThrowsUnsupportedPlatformWhenDecryptingFileEncryptedOnDifferentPlatform() {
+        
+        // given
+        let uuid1 = UUID()
+        let uuid2 = UUID()
+        let password = "1235678"
+        let message = "123456789".data(using: .utf8)!
+        
+        // then when
+        do {
+            let encryptedMessage = try encrypt(message, passphrase: ChaCha20Encryption.Passphrase(password: password, uuid: uuid1))
+            var modifiedMessage = [UInt8](encryptedMessage)
+            modifiedMessage[3] = 65 // replace I with A (A = Android)
+            _ = try decrypt(Data(bytes: modifiedMessage), passphrase: ChaCha20Encryption.Passphrase(password: password, uuid: uuid2))
+        } catch ChaCha20Encryption.EncryptionError.unsupportedPlatform {
+            return // success
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testThatItThrowsUnsupportedPlatformWhenDecryptingFileEncryptedWithUnsupportedVersion() {
+        
+        // given
+        let uuid1 = UUID()
+        let uuid2 = UUID()
+        let password = "1235678"
+        let message = "123456789".data(using: .utf8)!
+        
+        // then when
+        do {
+            let encryptedMessage = try encrypt(message, passphrase: ChaCha20Encryption.Passphrase(password: password, uuid: uuid1))
+            var modifiedMessage = [UInt8](encryptedMessage)
+            modifiedMessage[6] = 2 // change version number
+            _ = try decrypt(Data(bytes: modifiedMessage), passphrase: ChaCha20Encryption.Passphrase(password: password, uuid: uuid2))
+        } catch ChaCha20Encryption.EncryptionError.unsupportedPlatform {
             return // success
         } catch {
             XCTFail()

--- a/WireCryptoboxTests/ChaCha20EncryptionTests.swift
+++ b/WireCryptoboxTests/ChaCha20EncryptionTests.swift
@@ -158,6 +158,20 @@ class ChaCha20EncryptionTests: XCTestCase {
         // then
         XCTAssertEqual(decryptedMessage, messageData)
     }
+    
+    func testThatDecryptionWorks() throws {
+        
+        // given
+        let expectedMessage = "123456789"
+        let passphrase = ChaCha20Encryption.Passphrase(password: "1235678", uuid: UUID(uuidString: "71DE4781-9EC7-4ED4-BADE-690C5A9732C6")!)
+        let encryptedMessage =  Data(base64Encoded: "V0JVSQAAAT5xxW76YX91IgLvJwXeC5x+q/8To15mBzbsA6rc5Dzf7xRyWH+LYv+bscKxj3c7Fl7trr/9qt78lgA5ZtyjK7d2ZBdSYl4HLskPjyUIseTjAZjGKt+7MEXp8aVBey8ooGep")!
+        
+        // when
+        let decryptedMessage = try decrypt(encryptedMessage, passphrase: passphrase)
+        
+        // then
+        XCTAssertEqual(decryptedMessage, expectedMessage.data(using: .utf8)!)
+    }
         
     func testThatEncryptionAndDecryptionWorks_ToDisk() throws {
         


### PR DESCRIPTION
## What's new in this PR?

When encrypting a backup it useful to add some additional metadata together with the encrypted data in order to give more useful error messages when decrypting a backup from the wrong account or wrong platform.