### PR TITLE
Caching of the encrypted payloads

### DIFF
--- a/WireCryptobox.xcodeproj/project.pbxproj
+++ b/WireCryptobox.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		87AE8D48207BB3380058715E /* crypto_box_curve25519xsalsa20poly1305.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8D07207BB3370058715E /* crypto_box_curve25519xsalsa20poly1305.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87AE8D49207BB3380058715E /* crypto_generichash_blake2b.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8D08207BB3370058715E /* crypto_generichash_blake2b.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87AE8D4A207BB3380058715E /* crypto_sign_edwards25519sha512batch.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8D09207BB3370058715E /* crypto_sign_edwards25519sha512batch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87B43C2C20F394E90031DE41 /* EncryptionSessionsDirectoryCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B43C2B20F394E90031DE41 /* EncryptionSessionsDirectoryCaching.swift */; };
+		87B43C2F20F3973F0031DE41 /* EncryptionContextCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */; };
 		F10C8E241E9296BA00020408 /* WireSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F10C8E231E9296BA00020408 /* WireSystem.framework */; };
 		F10C8E251E92977000020408 /* WireSystem.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F10C8E231E9296BA00020408 /* WireSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F503032B1B8CFA2C0053E406 /* libcryptobox.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50303291B8CFA2C0053E406 /* libcryptobox.a */; };
@@ -234,6 +236,8 @@
 		87AE8D07207BB3370058715E /* crypto_box_curve25519xsalsa20poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_box_curve25519xsalsa20poly1305.h; sourceTree = "<group>"; };
 		87AE8D08207BB3370058715E /* crypto_generichash_blake2b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_generichash_blake2b.h; sourceTree = "<group>"; };
 		87AE8D09207BB3370058715E /* crypto_sign_edwards25519sha512batch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_sign_edwards25519sha512batch.h; sourceTree = "<group>"; };
+		87B43C2B20F394E90031DE41 /* EncryptionSessionsDirectoryCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionSessionsDirectoryCaching.swift; sourceTree = "<group>"; };
+		87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionContextCachingTests.swift; sourceTree = "<group>"; };
 		BA7EF9691B7109B600204A8E /* WireCryptoboxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WireCryptoboxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA7EF96F1B7109B600204A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F10C8E231E9296BA00020408 /* WireSystem.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireSystem.framework; path = Carthage/Build/iOS/WireSystem.framework; sourceTree = "<group>"; };
@@ -443,6 +447,7 @@
 				16460B7E206D456F0096B616 /* cbox.h */,
 				54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */,
 				5471A6771D242F8C0092A9A9 /* EncryptionSessionsDirectory.swift */,
+				87B43C2B20F394E90031DE41 /* EncryptionSessionsDirectoryCaching.swift */,
 				54B224801DBE89FD00FDB35E /* EncryptionSession+Debugging.swift */,
 				5421C5F81D2C152C00048251 /* NSData+CBox.swift */,
 				5471A6731D242D740092A9A9 /* PointerWrapper.swift */,
@@ -459,6 +464,7 @@
 			children = (
 				BA7EF96E1B7109B600204A8E /* Supporting Files */,
 				54A1573E1D23C00500EB3B4F /* EncryptionContextTests.swift */,
+				87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */,
 				16460B82206D47460096B616 /* ChaCha20EncryptionTests.swift */,
 				54B224821DBE92E200FDB35E /* EncryptionDebugTests.swift */,
 				54B949911D253E2E0041CC55 /* EncryptionSessionsDirectoryTests.swift */,
@@ -748,6 +754,7 @@
 				16460B81206D46CA0096B616 /* ChaCha20Encryption.swift in Sources */,
 				5421C5F91D2C152C00048251 /* NSData+CBox.swift in Sources */,
 				54EA12241D2A9AA400D2CFD1 /* CryptoBoxError.swift in Sources */,
+				87B43C2C20F394E90031DE41 /* EncryptionSessionsDirectoryCaching.swift in Sources */,
 				5471A6741D242D740092A9A9 /* PointerWrapper.swift in Sources */,
 				54B224811DBE89FD00FDB35E /* EncryptionSession+Debugging.swift in Sources */,
 				54C69DDA1D216A6B0060FBEC /* EncryptionContext.swift in Sources */,
@@ -770,6 +777,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				87B43C2F20F3973F0031DE41 /* EncryptionContextCachingTests.swift in Sources */,
 				54B949921D253E2E0041CC55 /* EncryptionSessionsDirectoryTests.swift in Sources */,
 				54A1573F1D23C00500EB3B4F /* EncryptionContextTests.swift in Sources */,
 				54B949941D2541350041CC55 /* TestHelper.swift in Sources */,

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -106,6 +106,10 @@ public final class EncryptionSessionsDirectory : NSObject {
     
     /// Returns the caching version of the encryptor, that is only going to encrypt the given data once.
     public lazy var cachingEncryptor: Encryptor = CachingEncryptor(encryptor: self)
+    
+    public func flushEncryptionCache() {
+        cachingEncryptor = CachingEncryptor(encryptor: self)
+    }
 }
 
 // MARK: - Encryption sessions

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -103,13 +103,43 @@ public final class EncryptionSessionsDirectory : NSObject {
     deinit {
         self.commitCache()
     }
+    
+    /// Returns the caching version of the encryptor, that is only going to encrypt the given data once.
+    public lazy var cachingEncryptor: Encryptor = CachingEncryptor(encryptor: self)
 }
 
-// MARK: - Accessing sessions
-extension EncryptionSessionsDirectory {
-    
+// MARK: - Encryption sessions
+public protocol EncryptionSessionManager {
     /// Migrate session to a new identifier, if a session with the old identifier exists
     /// and a session with the new identifier does not exist
+    func migrateSession(from previousIdentifier: String, to newIdentifier: EncryptionSessionIdentifier)
+    
+    /// Creates a session to a client using a prekey of that client
+    /// The session is not saved to disk until the cache is committed
+    /// - throws: CryptoBox error in case of lower-level error
+    func createClientSession(_ identifier: EncryptionSessionIdentifier, base64PreKeyString: String) throws
+    
+    /// Creates a session to a client using a prekey message from that client
+    /// The session is not saved to disk until the cache is committed
+    /// - returns: the plaintext
+    /// - throws: CryptoBox error in case of lower-level error
+    func createClientSessionAndReturnPlaintext(for identifier: EncryptionSessionIdentifier, prekeyMessage: Data) throws -> Data
+    
+    /// Deletes a session with a client
+    func delete(_ identifier: EncryptionSessionIdentifier)
+    
+    /// Returns true if there is an existing session for this client ID
+    func hasSession(for identifier: EncryptionSessionIdentifier) -> Bool
+    
+    /// Closes all transient sessions without saving them
+    func discardCache()
+    
+    /// Returns the remote fingerprint of a encryption session
+    func fingerprint(for identifier: EncryptionSessionIdentifier) -> Data?
+}
+
+extension EncryptionSessionsDirectory: EncryptionSessionManager {
+    
     public func migrateSession(from previousIdentifier: String, to newIdentifier: EncryptionSessionIdentifier) {
         
         let previousSessionIdentifier = EncryptionSessionIdentifier(rawValue: previousIdentifier)
@@ -144,9 +174,6 @@ extension EncryptionSessionsDirectory {
         
     }
     
-    /// Creates a session to a client using a prekey of that client
-    /// The session is not saved to disk until the cache is committed
-    /// - throws: CryptoBox error in case of lower-level error
     public func createClientSession(_ identifier: EncryptionSessionIdentifier, base64PreKeyString: String) throws {
         
         // validate
@@ -182,10 +209,6 @@ extension EncryptionSessionsDirectory {
         session.dumpSessionContent()
     }
     
-    /// Creates a session to a client using a prekey message from that client
-    /// The session is not saved to disk until the cache is committed
-    /// - returns: the plaintext
-    /// - throws: CryptoBox error in case of lower-level error
     public func createClientSessionAndReturnPlaintext(for identifier: EncryptionSessionIdentifier, prekeyMessage: Data) throws -> Data {
         let context = self.validateContext()
         let cbsession = _CBoxSession()
@@ -213,7 +236,6 @@ extension EncryptionSessionsDirectory {
         return plainText
     }
     
-    /// Deletes a session with a client
     public func delete(_ identifier: EncryptionSessionIdentifier) {
         let context = self.validateContext()
         self.discardFromCache(identifier)
@@ -224,10 +246,87 @@ extension EncryptionSessionsDirectory {
             fatal("Error in deletion in cbox: \(result)")
         }
     }
+    
+    /// Returns an existing session for a client
+    /// - returns: a session if it exists, or nil if not there
+    fileprivate func clientSession(for identifier: EncryptionSessionIdentifier) -> EncryptionSession? {
+        let context = self.validateContext()
+        
+        // check cache
+        if let transientSession = self.pendingSessionsCache[identifier] {
+            zmLog.debug("Tried to load session for client \(identifier), session was already loaded")
+            return transientSession
+        }
+        
+        let cbsession = _CBoxSession()
+        let result = cbox_session_load(context.implementation.ptr, identifier.rawValue, &cbsession.ptr)
+        switch(result) {
+        case CBOX_SESSION_NOT_FOUND:
+            zmLog.debug("Tried to load session for client \(identifier), no session found")
+            return nil
+        case CBOX_SUCCESS:
+            let session = EncryptionSession(id: identifier,
+                                            session: cbsession,
+                                            requiresSave: false,
+                                            cryptoboxPath: self.generatingContext!.path)
+            self.pendingSessionsCache[identifier] = session
+            zmLog.debug("Loaded session for client \(identifier)")
+            session.dumpSessionContent()
+            return session
+        default:
+            fatalError("Error in loading from cbox: \(result)")
+        }
+    }
+    
+    public func hasSession(for identifier: EncryptionSessionIdentifier) -> Bool {
+        return (clientSession(for: identifier) != nil)
+    }
+    
+    public func discardCache() {
+        zmLog.debug("Discarded all sessions from cache")
+        self.pendingSessionsCache = [:]
+    }
+    
+    /// Save and unload all transient sessions
+    fileprivate func commitCache() {
+        for (_, session) in self.pendingSessionsCache {
+            session.save(self.box)
+        }
+        discardCache()
+    }
+    
+    /// Closes a transient session. Any unsaved change will be lost
+    fileprivate func discardFromCache(_ identifier: EncryptionSessionIdentifier) {
+        zmLog.debug("Discarded session \(identifier.rawValue) from cache")
+        self.pendingSessionsCache.removeValue(forKey: identifier)
+    }
+    
+    /// Saves the cached session for a client and removes it from the cache
+    fileprivate func saveSession(_ identifier: EncryptionSessionIdentifier) {
+        guard let session = pendingSessionsCache[identifier] else {
+            return
+        }
+        session.save(self.box)
+        discardFromCache(identifier)
+    }
+    
+    public func fingerprint(for identifier: EncryptionSessionIdentifier) -> Data? {
+        guard let session = self.clientSession(for: identifier) else {
+            return nil
+        }
+        return session.remoteFingerprint
+    }
+}
+
+public protocol PrekeyGeneratorType {
+    func generatePrekey(_ id: UInt16) throws -> String
+    func generateLastPrekey() throws -> String
+    func generatePrekeys(_ range: CountableRange<UInt16>) throws -> [(id: UInt16, prekey: String)]
+    func generatePrekeys(_ nsRange: NSRange) throws -> [[String : AnyObject]]
 }
 
 // MARK: - Prekeys
-extension EncryptionSessionsDirectory {
+extension EncryptionSessionsDirectory: PrekeyGeneratorType {
     
     /// Generates one prekey of the given ID. If the prekey exists already,
     /// it will replace that prekey
@@ -283,87 +382,6 @@ extension _CBox {
             fatal("Can't get local fingerprint") // this is so rare, that we don't even throw
         }
         return Data.moveFromCBoxVector(vectorBacking)!
-    }
-}
-
-extension EncryptionSessionsDirectory {
-    
-    /// Returns the remote fingerprint of a encryption session
-    public func fingerprint(for identifier: EncryptionSessionIdentifier) -> Data? {
-        guard let session = self.clientSession(for: identifier) else {
-            return nil
-        }
-        return session.remoteFingerprint
-    }
-}
-
-
-// MARK: - Sessions cache management
-extension EncryptionSessionsDirectory {
-    
-    /// Returns an existing session for a client
-    /// - returns: a session if it exists, or nil if not there
-    fileprivate func clientSession(for identifier: EncryptionSessionIdentifier) -> EncryptionSession? {
-        let context = self.validateContext()
-        
-        // check cache
-        if let transientSession = self.pendingSessionsCache[identifier] {
-            zmLog.debug("Tried to load session for client \(identifier), session was already loaded")
-            return transientSession
-        }
-        
-        let cbsession = _CBoxSession()
-        let result = cbox_session_load(context.implementation.ptr, identifier.rawValue, &cbsession.ptr)
-        switch(result) {
-        case CBOX_SESSION_NOT_FOUND:
-            zmLog.debug("Tried to load session for client \(identifier), no session found")
-            return nil
-        case CBOX_SUCCESS:
-            let session = EncryptionSession(id: identifier,
-                                            session: cbsession,
-                                            requiresSave: false,
-                                            cryptoboxPath: self.generatingContext!.path)
-            self.pendingSessionsCache[identifier] = session
-            zmLog.debug("Loaded session for client \(identifier)")
-            session.dumpSessionContent()
-            return session
-        default:
-            fatalError("Error in loading from cbox: \(result)")
-        }
-    }
-    
-    /// Returns true if there is an existing session for this client ID
-    public func hasSession(for identifier: EncryptionSessionIdentifier) -> Bool {
-        return (clientSession(for: identifier) != nil)
-    }
-    
-    /// Closes all transient sessions without saving them
-    public func discardCache() {
-        zmLog.debug("Discarded all sessions from cache")
-        self.pendingSessionsCache = [:]
-    }
-    
-    /// Save and unload all transient sessions
-    fileprivate func commitCache() {
-        for (_, session) in self.pendingSessionsCache {
-            session.save(self.box)
-        }
-        discardCache()
-    }
-    
-    /// Closes a transient session. Any unsaved change will be lost
-    fileprivate func discardFromCache(_ identifier: EncryptionSessionIdentifier) {
-        zmLog.debug("Discarded session \(identifier.rawValue) from cache")
-        self.pendingSessionsCache.removeValue(forKey: identifier)
-    }
-
-    /// Saves the cached session for a client and removes it from the cache
-    fileprivate func saveSession(_ identifier: EncryptionSessionIdentifier) {
-        guard let session = pendingSessionsCache[identifier] else {
-            return
-        }
-        session.save(self.box)
-        discardFromCache(identifier)
     }
 }
 
@@ -435,12 +453,24 @@ class EncryptionSession {
     }
 }
 
-// MARK: - Encryption and decryption
-extension EncryptionSessionsDirectory {
-    
+// MARK: - Encryption
+public protocol Encryptor: class {
     /// Encrypts data for a client
     /// It immediately saves the session
     /// - returns: nil if there is no session with that client
+    func encrypt(_ plainText: Data, for recipientIdentifier: EncryptionSessionIdentifier) throws -> Data
+}
+
+// MARK: - Decryption
+public protocol Decryptor: class {
+    /// Decrypts data from a client
+    /// The session is not saved to disk until the cache is committed
+    /// - returns: nil if there is no session with that client
+    func decrypt(_ cypherText: Data, from senderIdentifier: EncryptionSessionIdentifier) throws -> Data
+}
+
+extension EncryptionSessionsDirectory: Encryptor, Decryptor {
+
     public func encrypt(_ plainText: Data, for recipientIdentifier: EncryptionSessionIdentifier) throws -> Data {
         _ = self.validateContext()
         guard let session = self.clientSession(for: recipientIdentifier) else {
@@ -452,9 +482,6 @@ extension EncryptionSessionsDirectory {
         return cypherText
     }
     
-    /// Decrypts data from a client
-    /// The session is not saved to disk until the cache is committed
-    /// - returns: nil if there is no session with that client
     public func decrypt(_ cypherText: Data, from senderIdentifier: EncryptionSessionIdentifier) throws -> Data {
         _ = self.validateContext()
         guard let session = self.clientSession(for: senderIdentifier) else {
@@ -566,3 +593,4 @@ public struct EncryptionSessionIdentifier : Hashable, Equatable {
 public func ==(lhs: EncryptionSessionIdentifier, rhs: EncryptionSessionIdentifier) -> Bool {
     return lhs.rawValue == rhs.rawValue
 }
+

--- a/WireCryptobox/EncryptionSessionsDirectoryCaching.swift
+++ b/WireCryptobox/EncryptionSessionsDirectoryCaching.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+// Caching proxy for @c backingEncryptor
+class CachingEncryptor: Encryptor {
+    private weak var backingEncryptor: Encryptor?
+    private let cache = NSCache<NSString, NSData>()
+    
+    public init(encryptor: Encryptor) {
+        backingEncryptor = encryptor
+        
+        cache.countLimit = 100
+        cache.name = "Encrypted payloads cache"
+        cache.totalCostLimit = 100_000 // Max 100 KB of data
+    }
+    
+    public func encrypt(_ plainText: Data, for recipientIdentifier: WireCryptobox.EncryptionSessionIdentifier) throws -> Data {
+        guard let backingEncryptor = self.backingEncryptor else {
+            fatalError("Backing enryptor missing")
+        }
+        
+        let cacheID: NSString = ("\(plainText.hashValue)" + recipientIdentifier.rawValue) as NSString
+        
+        if let cachedObject = cache.object(forKey: cacheID) {
+            return cachedObject as Data
+        }
+        else {
+            let data = try backingEncryptor.encrypt(plainText, for: recipientIdentifier)
+            cache.setObject(data as NSData, forKey: cacheID, cost: data.count)
+            return data
+        }
+    }
+}

--- a/WireCryptoboxTests/EncryptionContextCachingTests.swift
+++ b/WireCryptoboxTests/EncryptionContextCachingTests.swift
@@ -1,0 +1,138 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+@testable import WireCryptobox
+
+let someTextToEncrypt = "ENCRYPT THIS!"
+
+class EncryptionContextCachingTests: XCTestCase {
+    func testThatItDoesNotCachePerDefault() {
+        // GIVEN
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        let expectation = self.expectation(description: "Encryption succeeded")
+        
+        // WHEN
+        mainContext.perform { sessionContext in
+            try! sessionContext.createClientSession(hardcodedClientId, base64PreKeyString: hardcodedPrekey)
+            
+            let encryptedDataNonCachedFirst  = try! sessionContext.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+            let encryptedDataNonCachedSecond = try! sessionContext.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+            
+            XCTAssertNotEqual(encryptedDataNonCachedFirst, encryptedDataNonCachedSecond)
+            
+            expectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 0) { _ in }
+    }
+    
+    func testThatItCachesWhenRequested() {
+        // GIVEN
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        let expectation = self.expectation(description: "Encryption succeeded")
+        
+        // WHEN
+        mainContext.perform { sessionContext in
+            try! sessionContext.createClientSession(hardcodedClientId, base64PreKeyString: hardcodedPrekey)
+            
+            let encryptedDataFirst  = try! sessionContext.cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+            let encryptedDataSecond = try! sessionContext.cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+            
+            XCTAssertEqual(encryptedDataFirst, encryptedDataSecond)
+            
+            expectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 0) { _ in }
+    }
+    
+    func testThatCacheKeyDependsOnData() {
+        // GIVEN
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        let expectation = self.expectation(description: "Encryption succeeded")
+        
+        // WHEN
+        mainContext.perform { sessionContext in
+            try! sessionContext.createClientSession(hardcodedClientId, base64PreKeyString: hardcodedPrekey)
+            
+            let encryptedDataFirst  = try! sessionContext.cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+            let encryptedDataSecond = try! sessionContext.cachingEncryptor.encrypt(someTextToEncrypt.appending(someTextToEncrypt).data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+            
+            XCTAssertNotEqual(encryptedDataFirst, encryptedDataSecond)
+            
+            expectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 0) { _ in }
+    }
+    
+    func testThatCacheKeyDependsOnSessionId() throws {
+        // GIVEN
+        class DebugEncryptor: Encryptor {
+            var index: Int = 0
+            func encrypt(_ plainText: Data, for recipientIdentifier: EncryptionSessionIdentifier) throws -> Data {
+                var result = plainText
+                result.append(recipientIdentifier.rawValue.data(using: .utf8)!)
+                result.append("\(index)".data(using: .utf8)!)
+                return result
+            }
+        }
+        let debugEncryptor = DebugEncryptor()
+        let cachingEncryptor = CachingEncryptor(encryptor: debugEncryptor)
+        
+        let otherSessionIdentifier = EncryptionSessionIdentifier(rawValue: "1e9b4e187a9eb716")
+        // WHEN
+        
+        let data1 = try cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+        let data2 = try cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: otherSessionIdentifier)
+        // THEN
+        XCTAssertNotEqual(data1, data2)
+    }
+    
+    func testThatItCachesWhenRequested_SimpleSetup() throws {
+        // GIVEN
+        class DebugEncryptor: Encryptor {
+            var index: Int = 0
+            func encrypt(_ plainText: Data, for recipientIdentifier: EncryptionSessionIdentifier) throws -> Data {
+                var result = plainText
+                result.append(recipientIdentifier.rawValue.data(using: .utf8)!)
+                result.append("\(index)".data(using: .utf8)!)
+                return result
+            }
+        }
+        let debugEncryptor = DebugEncryptor()
+        let cachingEncryptor = CachingEncryptor(encryptor: debugEncryptor)
+        // WHEN
+        
+        let data1 = try cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+        let data2 = try cachingEncryptor.encrypt(someTextToEncrypt.data(using: String.Encoding.utf8)!, for: hardcodedClientId)
+        // THEN
+        XCTAssertEqual(data1, data2)
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Other clients (Web) noticed that sometimes they cannot decrypt the message from the iOS client.

### Causes

When the iOS device is online, but the requests cannot go through, each time Wire app is trying to send the request for the message upload we are encrypting the message payload.

The problem is that with every encryption we advance the encryption key forward, so if device is offline long enough, the receiver would reject the message (it's too far in the future).

### Solutions

I introduced the property `cachingEncryptor` on `EncryptionSessionsDirectory` that returns the `Encryptor` that is caching the payload using the key of plaintext message text hash + session ID.

When the request is generated, we'll encrypt using `cachingEncryptor` and automatically get the old payload if we encrypt the same message for the same receiver. 

When the request is successful, we reset the cache with `flushEncryptionCache()`.

## Notes

I moved the methods of `EncryptionSessionsDirectory` to the protocols, so it allows the implementation of the `Encryptor` variant as well as the mock encryptor in tests.

