### PR TITLE
Enable safe public logs

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "wireapp/wire-ios-system" ~> 28.0
+github "wireapp/wire-ios-utilities" ~> 35.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "wireapp/wire-ios-system" "28.0.0"
+github "wireapp/wire-ios-system" "28.0.4"
+github "wireapp/wire-ios-utilities" "35.1.0"

--- a/WireCryptobox.xcodeproj/project.pbxproj
+++ b/WireCryptobox.xcodeproj/project.pbxproj
@@ -31,10 +31,11 @@
 		54B949941D2541350041CC55 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B949931D2541350041CC55 /* TestHelper.swift */; };
 		54C69DDA1D216A6B0060FBEC /* EncryptionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */; };
 		54EA12241D2A9AA400D2CFD1 /* CryptoBoxError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */; };
-		6387925C2391511D00FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387925B2391511D00FD23CF /* WireUtilities.framework */; };
-		6387925D2391511D00FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387925B2391511D00FD23CF /* WireUtilities.framework */; };
-		6387925E2391516C00FD23CF /* WireUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6387925B2391511D00FD23CF /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		638792A623956F9300FD23CF /* Data+SafeForLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638792A523956F9300FD23CF /* Data+SafeForLogging.swift */; };
+		638792AE23957A7D00FD23CF /* WireSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 638792AC23957A7D00FD23CF /* WireSystem.framework */; };
+		638792AF23957A7D00FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 638792AD23957A7D00FD23CF /* WireUtilities.framework */; };
+		638792C223957C3F00FD23CF /* WireSystem.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 638792AC23957A7D00FD23CF /* WireSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		638792C323957C3F00FD23CF /* WireUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 638792AD23957A7D00FD23CF /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		870121FD20F4D2FE001E6342 /* GenericHashBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */; };
 		87AE8D0A207BB3380058715E /* crypto_stream_salsa2012.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8CC9207BB3370058715E /* crypto_stream_salsa2012.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87AE8D0B207BB3380058715E /* crypto_auth.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8CCA207BB3370058715E /* crypto_auth.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -97,8 +98,6 @@
 		87AE8D4A207BB3380058715E /* crypto_sign_edwards25519sha512batch.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8D09207BB3370058715E /* crypto_sign_edwards25519sha512batch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87B43C2F20F3973F0031DE41 /* EncryptionContextCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */; };
 		87B43C5920F4AAA00031DE41 /* GenericHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B43C5820F4AAA00031DE41 /* GenericHash.swift */; };
-		F10C8E241E9296BA00020408 /* WireSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F10C8E231E9296BA00020408 /* WireSystem.framework */; };
-		F10C8E251E92977000020408 /* WireSystem.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F10C8E231E9296BA00020408 /* WireSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F503032B1B8CFA2C0053E406 /* libcryptobox.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50303291B8CFA2C0053E406 /* libcryptobox.a */; };
 		F503032C1B8CFA2C0053E406 /* libsodium.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F503032A1B8CFA2C0053E406 /* libsodium.a */; };
 /* End PBXBuildFile section */
@@ -127,8 +126,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				6387925E2391516C00FD23CF /* WireUtilities.framework in CopyFiles */,
-				F10C8E251E92977000020408 /* WireSystem.framework in CopyFiles */,
+				638792C223957C3F00FD23CF /* WireSystem.framework in CopyFiles */,
+				638792C323957C3F00FD23CF /* WireUtilities.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -179,8 +178,9 @@
 		54B949931D2541350041CC55 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncryptionContext.swift; sourceTree = "<group>"; };
 		54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoBoxError.swift; sourceTree = "<group>"; };
-		6387925B2391511D00FD23CF /* WireUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireUtilities.framework; path = Carthage/Build/iOS/WireUtilities.framework; sourceTree = "<group>"; };
 		638792A523956F9300FD23CF /* Data+SafeForLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SafeForLogging.swift"; sourceTree = "<group>"; };
+		638792AC23957A7D00FD23CF /* WireSystem.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireSystem.framework; path = Carthage/Build/iOS/WireSystem.framework; sourceTree = "<group>"; };
+		638792AD23957A7D00FD23CF /* WireUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireUtilities.framework; path = Carthage/Build/iOS/WireUtilities.framework; sourceTree = "<group>"; };
 		870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericHashBuilderTests.swift; sourceTree = "<group>"; };
 		87AE8CC9207BB3370058715E /* crypto_stream_salsa2012.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_stream_salsa2012.h; sourceTree = "<group>"; };
 		87AE8CCA207BB3370058715E /* crypto_auth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_auth.h; sourceTree = "<group>"; };
@@ -247,7 +247,6 @@
 		BA7EF96F1B7109B600204A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EFF7A46D2271DBB100F1AC33 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		EFF7A46E2271DBB100F1AC33 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
-		F10C8E231E9296BA00020408 /* WireSystem.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireSystem.framework; path = Carthage/Build/iOS/WireSystem.framework; sourceTree = "<group>"; };
 		F1E148D0207D06EF00F81833 /* ios-test-target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-target.xcconfig"; sourceTree = "<group>"; };
 		F1E148D1207D06EF00F81833 /* ios-test-host.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-host.xcconfig"; sourceTree = "<group>"; };
 		F1E148D3207D06EF00F81833 /* tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = tests.xcconfig; sourceTree = "<group>"; };
@@ -261,10 +260,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F10C8E241E9296BA00020408 /* WireSystem.framework in Frameworks */,
 				0928E2601BA0785F0057232E /* libcryptobox.a in Frameworks */,
-				6387925C2391511D00FD23CF /* WireUtilities.framework in Frameworks */,
 				0928E2611BA0785F0057232E /* libsodium.a in Frameworks */,
+				638792AE23957A7D00FD23CF /* WireSystem.framework in Frameworks */,
+				638792AF23957A7D00FD23CF /* WireUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,7 +271,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6387925D2391511D00FD23CF /* WireUtilities.framework in Frameworks */,
 				5471A66E1D24221A0092A9A9 /* WireCryptobox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -503,8 +501,8 @@
 		F10C8E221E9296BA00020408 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6387925B2391511D00FD23CF /* WireUtilities.framework */,
-				F10C8E231E9296BA00020408 /* WireSystem.framework */,
+				638792AC23957A7D00FD23CF /* WireSystem.framework */,
+				638792AD23957A7D00FD23CF /* WireUtilities.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -854,6 +852,7 @@
 			baseConfigurationReference = F1E148D1207D06EF00F81833 /* ios-test-host.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "test-host/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.marco83.test-host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -864,6 +863,7 @@
 			baseConfigurationReference = F1E148D1207D06EF00F81833 /* ios-test-host.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "test-host/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.marco83.test-host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/WireCryptobox.xcodeproj/project.pbxproj
+++ b/WireCryptobox.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		54B949941D2541350041CC55 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B949931D2541350041CC55 /* TestHelper.swift */; };
 		54C69DDA1D216A6B0060FBEC /* EncryptionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */; };
 		54EA12241D2A9AA400D2CFD1 /* CryptoBoxError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */; };
+		638792502390322800FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387924F2390322800FD23CF /* WireUtilities.framework */; };
+		638792512390323000FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387924F2390322800FD23CF /* WireUtilities.framework */; };
+		638792522390328400FD23CF /* WireUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6387924F2390322800FD23CF /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		870121FD20F4D2FE001E6342 /* GenericHashBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */; };
 		87AE8D0A207BB3380058715E /* crypto_stream_salsa2012.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8CC9207BB3370058715E /* crypto_stream_salsa2012.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87AE8D0B207BB3380058715E /* crypto_auth.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8CCA207BB3370058715E /* crypto_auth.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -123,6 +126,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				638792522390328400FD23CF /* WireUtilities.framework in CopyFiles */,
 				F10C8E251E92977000020408 /* WireSystem.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -174,6 +178,7 @@
 		54B949931D2541350041CC55 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncryptionContext.swift; sourceTree = "<group>"; };
 		54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoBoxError.swift; sourceTree = "<group>"; };
+		6387924F2390322800FD23CF /* WireUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireUtilities.framework; path = Carthage/Build/iOS/WireUtilities.framework; sourceTree = "<group>"; };
 		870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericHashBuilderTests.swift; sourceTree = "<group>"; };
 		87AE8CC9207BB3370058715E /* crypto_stream_salsa2012.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_stream_salsa2012.h; sourceTree = "<group>"; };
 		87AE8CCA207BB3370058715E /* crypto_auth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_auth.h; sourceTree = "<group>"; };
@@ -256,6 +261,7 @@
 			files = (
 				F10C8E241E9296BA00020408 /* WireSystem.framework in Frameworks */,
 				0928E2601BA0785F0057232E /* libcryptobox.a in Frameworks */,
+				638792502390322800FD23CF /* WireUtilities.framework in Frameworks */,
 				0928E2611BA0785F0057232E /* libsodium.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -264,6 +270,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				638792512390323000FD23CF /* WireUtilities.framework in Frameworks */,
 				5471A66E1D24221A0092A9A9 /* WireCryptobox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -493,6 +500,7 @@
 		F10C8E221E9296BA00020408 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6387924F2390322800FD23CF /* WireUtilities.framework */,
 				F10C8E231E9296BA00020408 /* WireSystem.framework */,
 			);
 			name = Frameworks;
@@ -727,7 +735,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "DIRECTORY=\"${PROJECT_DIR}/../build\"\nexport PATH=$PATH:/usr/local/bin\nhash curl || exit 1 # if this fires, you don't have wget installed!\nmake cryptobox-\"${CRYPTOBOX_VERSION}\"\ncp build/include/cbox.h WireCryptobox/cbox.h";
+			shellScript = "DIRECTORY=\"${PROJECT_DIR}/../build\"\nexport PATH=$PATH:/usr/local/bin\nhash curl || exit 1 # if this fires, you don't have wget installed!\nmake cryptobox-\"${CRYPTOBOX_VERSION}\"\ncp build/include/cbox.h WireCryptobox/cbox.h\n";
 		};
 		5459C4B81C0FB0F600F4963F /* Placeholder Carthage folder */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -741,7 +749,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p Carthage/Build/iOS";
+			shellScript = "mkdir -p Carthage/Build/iOS\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/WireCryptobox.xcodeproj/project.pbxproj
+++ b/WireCryptobox.xcodeproj/project.pbxproj
@@ -31,9 +31,10 @@
 		54B949941D2541350041CC55 /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B949931D2541350041CC55 /* TestHelper.swift */; };
 		54C69DDA1D216A6B0060FBEC /* EncryptionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */; };
 		54EA12241D2A9AA400D2CFD1 /* CryptoBoxError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */; };
-		638792502390322800FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387924F2390322800FD23CF /* WireUtilities.framework */; };
-		638792512390323000FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387924F2390322800FD23CF /* WireUtilities.framework */; };
-		638792522390328400FD23CF /* WireUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6387924F2390322800FD23CF /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6387925C2391511D00FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387925B2391511D00FD23CF /* WireUtilities.framework */; };
+		6387925D2391511D00FD23CF /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6387925B2391511D00FD23CF /* WireUtilities.framework */; };
+		6387925E2391516C00FD23CF /* WireUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6387925B2391511D00FD23CF /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		638792A623956F9300FD23CF /* Data+SafeForLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638792A523956F9300FD23CF /* Data+SafeForLogging.swift */; };
 		870121FD20F4D2FE001E6342 /* GenericHashBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */; };
 		87AE8D0A207BB3380058715E /* crypto_stream_salsa2012.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8CC9207BB3370058715E /* crypto_stream_salsa2012.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87AE8D0B207BB3380058715E /* crypto_auth.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8CCA207BB3370058715E /* crypto_auth.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -126,7 +127,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				638792522390328400FD23CF /* WireUtilities.framework in CopyFiles */,
+				6387925E2391516C00FD23CF /* WireUtilities.framework in CopyFiles */,
 				F10C8E251E92977000020408 /* WireSystem.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -178,7 +179,8 @@
 		54B949931D2541350041CC55 /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncryptionContext.swift; sourceTree = "<group>"; };
 		54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoBoxError.swift; sourceTree = "<group>"; };
-		6387924F2390322800FD23CF /* WireUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireUtilities.framework; path = Carthage/Build/iOS/WireUtilities.framework; sourceTree = "<group>"; };
+		6387925B2391511D00FD23CF /* WireUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireUtilities.framework; path = Carthage/Build/iOS/WireUtilities.framework; sourceTree = "<group>"; };
+		638792A523956F9300FD23CF /* Data+SafeForLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SafeForLogging.swift"; sourceTree = "<group>"; };
 		870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericHashBuilderTests.swift; sourceTree = "<group>"; };
 		87AE8CC9207BB3370058715E /* crypto_stream_salsa2012.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_stream_salsa2012.h; sourceTree = "<group>"; };
 		87AE8CCA207BB3370058715E /* crypto_auth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_auth.h; sourceTree = "<group>"; };
@@ -261,7 +263,7 @@
 			files = (
 				F10C8E241E9296BA00020408 /* WireSystem.framework in Frameworks */,
 				0928E2601BA0785F0057232E /* libcryptobox.a in Frameworks */,
-				638792502390322800FD23CF /* WireUtilities.framework in Frameworks */,
+				6387925C2391511D00FD23CF /* WireUtilities.framework in Frameworks */,
 				0928E2611BA0785F0057232E /* libsodium.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -270,7 +272,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				638792512390323000FD23CF /* WireUtilities.framework in Frameworks */,
+				6387925D2391511D00FD23CF /* WireUtilities.framework in Frameworks */,
 				5471A66E1D24221A0092A9A9 /* WireCryptobox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -455,6 +457,7 @@
 				54C69DD91D216A6B0060FBEC /* EncryptionContext.swift */,
 				5471A6771D242F8C0092A9A9 /* EncryptionSessionsDirectory.swift */,
 				5421C5F81D2C152C00048251 /* NSData+CBox.swift */,
+				638792A523956F9300FD23CF /* Data+SafeForLogging.swift */,
 				5471A6731D242D740092A9A9 /* PointerWrapper.swift */,
 				54060B7C1DB771B400AEA9BB /* Logs.swift */,
 				54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */,
@@ -500,7 +503,7 @@
 		F10C8E221E9296BA00020408 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6387924F2390322800FD23CF /* WireUtilities.framework */,
+				6387925B2391511D00FD23CF /* WireUtilities.framework */,
 				F10C8E231E9296BA00020408 /* WireSystem.framework */,
 			);
 			name = Frameworks;
@@ -759,6 +762,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				16460B81206D46CA0096B616 /* ChaCha20Encryption.swift in Sources */,
+				638792A623956F9300FD23CF /* Data+SafeForLogging.swift in Sources */,
 				5421C5F91D2C152C00048251 /* NSData+CBox.swift in Sources */,
 				54EA12241D2A9AA400D2CFD1 /* CryptoBoxError.swift in Sources */,
 				5471A6741D242D740092A9A9 /* PointerWrapper.swift in Sources */,

--- a/WireCryptobox/Data+SafeForLogging.swift
+++ b/WireCryptobox/Data+SafeForLogging.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireUtilities
+
+extension Data: SafeForLoggingStringConvertible {
+    public var safeForLoggingDescription: String {
+        return "<\(self.readableHash)>"
+    }
+}

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import WireSystem
+import WireUtilities
 
 @objc enum EncryptionSessionError : Int {
     
@@ -173,7 +174,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
     
     public func migrateSession(from previousIdentifier: String, to newIdentifier: EncryptionSessionIdentifier) {
         
-        let previousSessionIdentifier = EncryptionSessionIdentifier(rawValue: previousIdentifier)
+        let previousSessionIdentifier = EncryptionSessionIdentifier(fromLegacyV1Identifier: previousIdentifier)
         // this scopes guarantee that `old` is released
         repeat {
             guard let old = clientSession(for: previousSessionIdentifier) else {
@@ -215,7 +216,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
 
         // check if pre-existing
         if clientSession(for: identifier) != nil {
-            zmLog.debug("Tried to create session for client \(identifier) with prekey but session already existed")
+            zmLog.safePublic("Tried to create session for client \(identifier) with prekey but session already existed")
             return
         }
         
@@ -228,7 +229,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
                                           prekeyData.count,
                                           &cbsession.ptr)
         }
-        zmLog.debug("Create session for client: \(identifier)")
+        zmLog.safePublic("Create session for client \(identifier)")
         
         try result.throwIfError()
 
@@ -252,7 +253,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
                                            &cbsession.ptr,
                                            &plainTextBacking)
         }
-        zmLog.debug("Create session for client \(identifier) from prekey message")
+        zmLog.safePublic("Create session for client \(identifier) from prekey message")
 
         try result.throwIfError()
 
@@ -269,7 +270,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
         let context = self.validateContext()
         self.discardFromCache(identifier)
         let result = cbox_session_delete(context.implementation.ptr, identifier.rawValue)
-        zmLog.debug("Delete session for client: \(identifier)")
+        zmLog.safePublic("Delete session for client \(identifier)")
 
         guard result == CBOX_SUCCESS else {
             fatal("Error in deletion in cbox: \(result)")
@@ -283,7 +284,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
         
         // check cache
         if let transientSession = self.pendingSessionsCache[identifier] {
-            zmLog.debug("Tried to load session for client \(identifier), session was already loaded")
+            zmLog.safePublic("Tried to load session for client \(identifier), session was already loaded")
             return transientSession
         }
         
@@ -291,7 +292,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
         let result = cbox_session_load(context.implementation.ptr, identifier.rawValue, &cbsession.ptr)
         switch(result) {
         case CBOX_SESSION_NOT_FOUND:
-            zmLog.debug("Tried to load session for client \(identifier), no session found")
+            zmLog.safePublic("Tried to load session for client \(identifier), no session found")
             return nil
         case CBOX_SUCCESS:
             let session = EncryptionSession(id: identifier,
@@ -299,7 +300,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
                                             requiresSave: false,
                                             cryptoboxPath: self.generatingContext!.path)
             self.pendingSessionsCache[identifier] = session
-            zmLog.debug("Loaded session for client \(identifier)")
+            zmLog.safePublic("Loaded session for client \(identifier)")
             return session
         default:
             fatalError("Error in loading from cbox: \(result)")
@@ -311,7 +312,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
     }
     
     public func discardCache() {
-        zmLog.debug("Discarded all sessions from cache")
+        zmLog.safePublic("Discarded all sessions from cache")
         self.pendingSessionsCache = [:]
     }
     
@@ -325,7 +326,7 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
     
     /// Closes a transient session. Any unsaved change will be lost
     fileprivate func discardFromCache(_ identifier: EncryptionSessionIdentifier) {
-        zmLog.debug("Discarded session \(identifier.rawValue) from cache")
+        zmLog.safePublic("Discarded session \(identifier) from cache")
         self.pendingSessionsCache.removeValue(forKey: identifier)
     }
     
@@ -475,14 +476,14 @@ class EncryptionSession {
     
     /// Closes the session in CBox
     fileprivate func closeInCryptobox() {
-        zmLog.debug("Closing cryptobox session \(id)")
+        zmLog.safePublic("Closing cryptobox session \(id)")
         cbox_session_close(self.implementation.ptr)
     }
     
     /// Save the session to disk
     fileprivate func save(_ cryptobox: _CBox) {
         if self.hasChanges {
-            zmLog.debug("Saving cryptobox session \(self.id)")
+            zmLog.safePublic("Saving cryptobox session \(id)")
             let result = cbox_session_save(cryptobox.ptr, self.implementation.ptr)
             switch(result) {
             case CBOX_SUCCESS:
@@ -519,7 +520,7 @@ extension EncryptionSessionsDirectory: Encryptor, Decryptor {
     public func encrypt(_ plainText: Data, for recipientIdentifier: EncryptionSessionIdentifier) throws -> Data {
         _ = self.validateContext()
         guard let session = self.clientSession(for: recipientIdentifier) else {
-            zmLog.debug("Can't find session to encrypt for client \(recipientIdentifier)")
+            zmLog.safePublic("Can't find session to encrypt for client \(recipientIdentifier)")
             throw EncryptionSessionError.encryptionFailed.error
         }
         let cypherText = try session.encrypt(plainText)
@@ -530,7 +531,7 @@ extension EncryptionSessionsDirectory: Encryptor, Decryptor {
     public func decrypt(_ cypherText: Data, from senderIdentifier: EncryptionSessionIdentifier) throws -> Data {
         _ = self.validateContext()
         guard let session = self.clientSession(for: senderIdentifier) else {
-            zmLog.debug("Can't find session to decrypt for client \(senderIdentifier)")
+            zmLog.safePublic("Can't find session to decrypt for client \(senderIdentifier)")
             throw EncryptionSessionError.decryptionFailed.error
         }
         return try session.decrypt(cypherText)
@@ -545,7 +546,7 @@ extension EncryptionSession {
     fileprivate func decrypt(_ cypher: Data) throws -> Data {
         var vectorBacking : OpaquePointer? = nil
 
-        zmLog.debug("Decrypting with session \(self.id)")
+        zmLog.safePublic("Decrypting with session \(id)")
 
         let result = cypher.withUnsafeBytes { (cypherPointer: UnsafeRawBufferPointer) -> CBoxResult in
             cbox_decrypt(self.implementation.ptr,
@@ -565,7 +566,7 @@ extension EncryptionSession {
     fileprivate func encrypt(_ plainText: Data) throws -> Data {
         var vectorBacking : OpaquePointer? = nil
         
-        zmLog.debug("Encrypting with session \(self.id)")
+        zmLog.safePublic("Encrypting with session \(id)")
         let result = plainText.withUnsafeBytes { (plainTextPointer: UnsafeRawBufferPointer) -> CBoxResult in
             cbox_encrypt(self.implementation.ptr,
                          plainTextPointer.baseAddress!.assumingMemoryBound(to: UInt8.self),
@@ -619,10 +620,25 @@ extension EncryptionSessionsDirectory {
 // MARK: - Session identifier
 public struct EncryptionSessionIdentifier : Hashable, Equatable {
     
-    public let rawValue : String
+    private let userId: String
+    private let clientId: String
     
-    public init(rawValue: String) {
-        self.rawValue = rawValue
+    public var rawValue: String {
+        guard !userId.isEmpty else {
+            return clientId
+        }
+        return "\(userId)_\(clientId)"
+    }
+    
+    public init(userId: String, clientId: String) {
+        self.userId = userId
+        self.clientId = clientId
+    }
+    
+    /// Use when migrating from old session identifier to new session identifier
+    init(fromLegacyV1Identifier clientId: String) {
+        self.userId = String()
+        self.clientId = clientId
     }
     
     public var hashValue: Int {
@@ -638,3 +654,8 @@ public func ==(lhs: EncryptionSessionIdentifier, rhs: EncryptionSessionIdentifie
     return lhs.rawValue == rhs.rawValue
 }
 
+extension EncryptionSessionIdentifier: SafeForLoggingStringConvertible {
+    public var safeForLoggingDescription: String {
+        return "<\(userId.readableHash)>_<\(clientId.readableHash)>"
+    }
+}

--- a/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -235,7 +235,7 @@ extension EncryptionSessionsDirectoryTests {
         // GIVEN
         // WHEN
         // THEN
-        XCTAssertNil(statusAlice.fingerprint(for: EncryptionSessionIdentifier(rawValue: "aa228899")))
+        XCTAssertNil(statusAlice.fingerprint(for: EncryptionSessionIdentifier(userId: "aa22", clientId: "8899")))
     }
 }
 
@@ -519,7 +519,7 @@ extension EncryptionSessionsDirectoryTests {
         
         
         // THEN
-        XCTAssertTrue(checkThatAMessageCanBeSent(.Bob))
+        XCTAssertTrue(checkThatAMessageCanBeSent(.Alice))
     }
     
     func testThatItWontMigrateIfNewSessionAlreadyExists() {
@@ -605,9 +605,9 @@ extension EncryptionSessionsDirectoryTests {
         var identifier : EncryptionSessionIdentifier {
             switch(self) {
             case .Alice:
-                return EncryptionSessionIdentifier(rawValue: "234ab2e4c45-a11c30")
+                return EncryptionSessionIdentifier(userId: "234ab2e4", clientId: "c45-a11c30")
             case .Bob:
-                return EncryptionSessionIdentifier(rawValue: bobIdentifierOverride ?? "a34affe3366-b0b0b0b")
+                return EncryptionSessionIdentifier(fromLegacyV1Identifier: bobIdentifierOverride ?? "a34affe3366-b0b0b0b")
             }
         }
         

--- a/WireCryptoboxTests/TestHelper.swift
+++ b/WireCryptoboxTests/TestHelper.swift
@@ -21,7 +21,7 @@ import Foundation
 import WireCryptobox
 
 /// sample client ID
-let hardcodedClientId = EncryptionSessionIdentifier(rawValue: "1e9b4e187a9eb715")
+let hardcodedClientId = EncryptionSessionIdentifier(userId: "1e9b4e18", clientId: "7a9eb715")
 
 /// sample prekey
 let hardcodedPrekey = "pQABAQUCoQBYIEIir0myj5MJTvs19t585RfVi1dtmL2nJsImTaNXszRwA6EAoQBYIGpa1sQFpCugwFJRfD18d9+TNJN2ZL3H0Mfj/0qZw0ruBPY="


### PR DESCRIPTION
## What's new in this PR?

Enabled public logging of the cryptobox events.
Sensitive information like `userId` and `deviceId` will be hashed. 

### Note

The `safePublic` method of `ZMLog` only accepts objects conforming to `SafeForLoggingStringConvertible`.
It will use the protocol's method `safeForLoggingDescription` instead of printing the object's description