### PR TITLE
[Fix] "Too distant future" encryption errors

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wireapp/wire-ios-system" "30.0.0"
+github "wireapp/wire-ios-system" "fix/distant-future-encryption-error-ZIOS-12701"
 github "wireapp/wire-ios-utilities" "36.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wireapp/wire-ios-system" "fix/distant-future-encryption-error-ZIOS-12701"
+github "wireapp/wire-ios-system" "30.1.0"
 github "wireapp/wire-ios-utilities" "36.0.0"

--- a/WireCryptobox/EncryptionContext.swift
+++ b/WireCryptobox/EncryptionContext.swift
@@ -84,8 +84,8 @@ public final class EncryptionContext : NSObject {
     fileprivate var performCount : UInt = 0
     
     // The maximum size of the end-to-end encrypted payload is defined by ZMClientMessageByteSizeExternalThreshold
-    // It's currently 128KB of data. We will allow up to 8 messages of maximum size to persist in the cache.
-    fileprivate let cache = Cache<GenericHash, Data>(maxCost: 1_000_000, maxElementsCount: 100)
+    // It's currently 128KB of data. NOTE that this cache is shared between all sessions in an encryption context.
+    fileprivate let cache = Cache<GenericHash, Data>(maxCost: 10_000_000, maxElementsCount: 100000)
 
     /// Opens cryptobox from a given folder
     /// - throws: CryptoBox error in case of lower-level error

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -123,11 +123,11 @@ public final class EncryptionSessionsDirectory : NSObject {
         let key = hash(for: plainText, recipient: recipientIdentifier)
         
         if let cachedObject = encryptionPayloadCache.value(for: key) {
-            zmLog.safePublic("Encrypting, cache hit: \(key)")
+            zmLog.safePublic("Encrypting, cache hit")
             return cachedObject
         }
         else {
-            zmLog.safePublic("Encrypting, cache miss: \(key)")
+            zmLog.debug("Encrypting, cache miss")
             let data = try encrypt(plainText, for: recipientIdentifier)
             let didPurgeData = encryptionPayloadCache.set(value: data, for: key, cost: data.count)
             

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -123,20 +123,25 @@ public final class EncryptionSessionsDirectory : NSObject {
         let key = hash(for: plainText, recipient: recipientIdentifier)
         
         if let cachedObject = encryptionPayloadCache.value(for: key) {
-            zmLog.debug("Cache hit: \(key)")
+            zmLog.safePublic("Encrypting, cache hit: \(key)")
             return cachedObject
         }
         else {
-            zmLog.debug("Cache miss: \(key)")
+            zmLog.safePublic("Encrypting, cache miss: \(key)")
             let data = try encrypt(plainText, for: recipientIdentifier)
-            encryptionPayloadCache.set(value: data, for: key, cost: data.count)
+            let didPurgeData = encryptionPayloadCache.set(value: data, for: key, cost: data.count)
+            
+            if didPurgeData {
+                zmLog.safePublic("Encrypting, cache limit reached")
+            }
+            
             return data
         }
     }
     
     /// Purges the cache of encrypted payloads created as the result of @c encryptCaching() call
     public func purgeEncryptedPayloadCache() {
-        zmLog.debug("Cache purged")
+        zmLog.safePublic("Encryption cache purged")
         encryptionPayloadCache.purge()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Users are reporting decryption errors of the type: "Too distant future".

### Causes

The "Too distant future" decryption error happens when you try to decrypt a message and your encryption session is missing 1000 or more messages which were encrypted before the message in question.

This scenario can happen if the sender encrypts a 1000 messages but doesn't send them, and then finally encrypts a final message which he/she does send.

Normally a client shouldn't try encrypt a messages over and over again without sending them, but in some conditions a client might not realize that it's offline and enter a loop where it tries to:

1. Encrypt a message 
2. Fail to send it.
3. Goto 1.

A solution for this scenario has already been implemented in the past https://github.com/wireapp/wire-ios-cryptobox/pull/22,  encryption payloads are cached and re-used when a send message request is re-tried. A theoretical problem with that solution is that the encryption cache is [fairly small](https://github.com/wireapp/wire-ios-cryptobox/blob/e888a18175fa35c33333cf0661fdc9d5e3e3f6db/WireCryptobox/EncryptionContext.swift#L88) and we might still get into an encryption loop if a message is sent to large a group with many devices (> 100). 

### Solutions

- Increase the size of the cache to 10Mb and the maximum number of cache entries to 100 000.
- Add logs when we reach the cache limit.

## Dependencies

Needs releases with:

- [x] https://github.com/wireapp/wire-ios-system/pull/51
