### PR TITLE
Dump payload of messages that were failed to decrypt

### DIFF
--- a/WireCryptobox/Data+SafeForLogging.swift
+++ b/WireCryptobox/Data+SafeForLogging.swift
@@ -23,3 +23,14 @@ extension Data: SafeForLoggingStringConvertible {
         return "<\(self.readableHash)>"
     }
 }
+
+// This allows for dump of data in safe logs. It's called "unsafe" because the data is
+// dumped as-is, no hashing is applied. Be aware of what you are dumping here.
+struct HexDumpUnsafeLoggingData: SafeForLoggingStringConvertible {
+    
+    let data: Data
+    
+    public var safeForLoggingDescription: String {
+        return data.zmHexEncodedString()
+    }
+}

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -564,6 +564,11 @@ extension EncryptionSession {
                          &vectorBacking)
         }
         
+        if (result != CBOX_DUPLICATE_MESSAGE && result != CBOX_DUPLICATE_MESSAGE) {
+            let encodedData = HexDumpUnsafeLoggingData(data: cypher)
+            zmLog.safePublic("Failed to decrypt cyphertext: \(encodedData)")
+        }
+        
         try result.throwIfError()
 
         self.hasChanges = true


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are decryption errors reported by a specific user that we can't reproduce. 


Looking at the logs, we notice that the error reported from Cyptobox is `CBOX_TOO_DISTANT_FUTURE`. However, this error is just the result of the first check that fails at the Cryptobox level. There might be more failures later that are more indicative of the actual issue (such as identity changed). Cryptobox will only report the first error and abort execution. Changing this behavior is a major API change which we don't want to entertain now.

As an alternative, for manual debugging, we can log the payload (envelope + cyphertext) every time decryption fails. This will allow us to ask the user to send us the logs, and when manually analyzing those logs, we can reconstruct the envelope of the message manually and check for other anomalies, which will hopefully allow us to understand where this issue is coming from.

### Notes

As soon as the bug is identified and addressed, we can remove this log.

### Testing

This has been tested manually on simulator, and confirm to produce the log:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/620000/87793973-42ab2600-c846-11ea-8a7c-20f98cb212d0.png">

Transcript:
```
2020-07-17 15:50:00.388045+0200 Wire[31829:831102] [cryptobox] Loaded encryption status - local fingerprint <f76239de> 
2020-07-17 15:50:00.399030+0200 Wire[31829:831102] [cryptobox] Loaded session for client <ee00c987>_<a1f3e89d> - fingerprint <55beOfab> 
2020-07-17 15:50:00.399545+0200 Wire[31829:831102] [cryptobox] Tried to load session for client <ee00c987>_<a1f3e89d>, session was already loaded - fingerprint <55be0fab> 
2020-07-17 15:50:00.399985+0200 Wire[31829:831102] [cryptobox] Decrypting with session <ee00c987>_<a1f3e89d> 
2020-07-17 15:50:00.400276+0200 Wire[31829:831102] [cryptobox] Failed to decrypt cyphertext: a3000101a10058202ce629de396eae75ac68ea1960927f1f8bfb1800784aeba1b1edd7da7f73407002587401a500508ddd1ef84f4268b86d168deb8220c6ef0100020103a1005820dc1fb8e290d774fdd5788da9c3cc72 9fc6a49a674fb5d742cf705a413d071bd304583450ec6e2c71a3792f399f4f572b91ad263a624185b68da6f75c0374bea8ca85ec00747959fe69463d7eb8e526cfbefe9023199691 
2020-07-17 15:50:00.403357+0200 Wire[31829:831102] [cryptobox] Saving cryptobox session <ee00c987>_<a1f3e89d> 
2020-07-17 15:50:00.409834+0200 Wire[31829:831102] [cryptobox] Discarded all sessions from cache 
```