### PR TITLE
Fix: log payload only in case of error

### DIFF
--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -564,7 +564,7 @@ extension EncryptionSession {
                          &vectorBacking)
         }
         
-        if (result != CBOX_DUPLICATE_MESSAGE && result != CBOX_DUPLICATE_MESSAGE) {
+        if (result != CBOX_DUPLICATE_MESSAGE && result != CBOX_SUCCESS) {
             let encodedData = HexDumpUnsafeLoggingData(data: cypher)
             zmLog.safePublic("Failed to decrypt cyphertext: \(encodedData)")
         }


### PR DESCRIPTION
## What's new in this PR?

Fixing invalid condition in https://github.com/wireapp/wire-ios-cryptobox/pull/40 so that it logs only on errors