### PR TITLE
[Feature] Swift wrapper for AES256-GCM encryption / decryption

### DIFF
--- a/WireCryptobox.xcodeproj/project.pbxproj
+++ b/WireCryptobox.xcodeproj/project.pbxproj
@@ -98,6 +98,9 @@
 		87AE8D4A207BB3380058715E /* crypto_sign_edwards25519sha512batch.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AE8D09207BB3370058715E /* crypto_sign_edwards25519sha512batch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87B43C2F20F3973F0031DE41 /* EncryptionContextCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */; };
 		87B43C5920F4AAA00031DE41 /* GenericHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B43C5820F4AAA00031DE41 /* GenericHash.swift */; };
+		EEA2B85D24DAD1E700C6659E /* AES256GCMEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2B85C24DAD1E700C6659E /* AES256GCMEncryption.swift */; };
+		EEA2B85F24DC26BD00C6659E /* AES256GCMEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2B85E24DC26BD00C6659E /* AES256GCMEncryptionTests.swift */; };
+		EEA2B86124DC3F1600C6659E /* Byte.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2B86024DC3F1600C6659E /* Byte.swift */; };
 		F503032B1B8CFA2C0053E406 /* libcryptobox.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F50303291B8CFA2C0053E406 /* libcryptobox.a */; };
 		F503032C1B8CFA2C0053E406 /* libsodium.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F503032A1B8CFA2C0053E406 /* libsodium.a */; };
 /* End PBXBuildFile section */
@@ -245,6 +248,9 @@
 		87B43C5820F4AAA00031DE41 /* GenericHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericHash.swift; sourceTree = "<group>"; };
 		BA7EF9691B7109B600204A8E /* WireCryptoboxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WireCryptoboxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA7EF96F1B7109B600204A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EEA2B85C24DAD1E700C6659E /* AES256GCMEncryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256GCMEncryption.swift; sourceTree = "<group>"; };
+		EEA2B85E24DC26BD00C6659E /* AES256GCMEncryptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256GCMEncryptionTests.swift; sourceTree = "<group>"; };
+		EEA2B86024DC3F1600C6659E /* Byte.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Byte.swift; sourceTree = "<group>"; };
 		EFF7A46D2271DBB100F1AC33 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		EFF7A46E2271DBB100F1AC33 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
 		F1E148D0207D06EF00F81833 /* ios-test-target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ios-test-target.xcconfig"; sourceTree = "<group>"; };
@@ -460,6 +466,8 @@
 				54060B7C1DB771B400AEA9BB /* Logs.swift */,
 				54EA12231D2A9AA400D2CFD1 /* CryptoBoxError.swift */,
 				16460B80206D46CA0096B616 /* ChaCha20Encryption.swift */,
+				EEA2B85C24DAD1E700C6659E /* AES256GCMEncryption.swift */,
+				EEA2B86024DC3F1600C6659E /* Byte.swift */,
 				87B43C5820F4AAA00031DE41 /* GenericHash.swift */,
 				0928E36F1BA090A00057232E /* Supporting Files */,
 			);
@@ -469,6 +477,7 @@
 		BA7EF96D1B7109B600204A8E /* CryptoboxTests */ = {
 			isa = PBXGroup;
 			children = (
+				EEA2B85E24DC26BD00C6659E /* AES256GCMEncryptionTests.swift */,
 				BA7EF96E1B7109B600204A8E /* Supporting Files */,
 				54A1573E1D23C00500EB3B4F /* EncryptionContextTests.swift */,
 				87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */,
@@ -759,11 +768,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EEA2B85D24DAD1E700C6659E /* AES256GCMEncryption.swift in Sources */,
 				16460B81206D46CA0096B616 /* ChaCha20Encryption.swift in Sources */,
 				638792A623956F9300FD23CF /* Data+SafeForLogging.swift in Sources */,
 				5421C5F91D2C152C00048251 /* NSData+CBox.swift in Sources */,
 				54EA12241D2A9AA400D2CFD1 /* CryptoBoxError.swift in Sources */,
 				5471A6741D242D740092A9A9 /* PointerWrapper.swift in Sources */,
+				EEA2B86124DC3F1600C6659E /* Byte.swift in Sources */,
 				87B43C5920F4AAA00031DE41 /* GenericHash.swift in Sources */,
 				54C69DDA1D216A6B0060FBEC /* EncryptionContext.swift in Sources */,
 				54060B7D1DB771B400AEA9BB /* Logs.swift in Sources */,
@@ -786,6 +797,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				87B43C2F20F3973F0031DE41 /* EncryptionContextCachingTests.swift in Sources */,
+				EEA2B85F24DC26BD00C6659E /* AES256GCMEncryptionTests.swift in Sources */,
 				54B949921D253E2E0041CC55 /* EncryptionSessionsDirectoryTests.swift in Sources */,
 				870121FD20F4D2FE001E6342 /* GenericHashBuilderTests.swift in Sources */,
 				54A1573F1D23C00500EB3B4F /* EncryptionContextTests.swift in Sources */,

--- a/WireCryptobox.xcodeproj/project.pbxproj
+++ b/WireCryptobox.xcodeproj/project.pbxproj
@@ -477,11 +477,11 @@
 		BA7EF96D1B7109B600204A8E /* CryptoboxTests */ = {
 			isa = PBXGroup;
 			children = (
-				EEA2B85E24DC26BD00C6659E /* AES256GCMEncryptionTests.swift */,
 				BA7EF96E1B7109B600204A8E /* Supporting Files */,
 				54A1573E1D23C00500EB3B4F /* EncryptionContextTests.swift */,
 				87B43C2D20F396F60031DE41 /* EncryptionContextCachingTests.swift */,
 				16460B82206D47460096B616 /* ChaCha20EncryptionTests.swift */,
+				EEA2B85E24DC26BD00C6659E /* AES256GCMEncryptionTests.swift */,
 				54B949911D253E2E0041CC55 /* EncryptionSessionsDirectoryTests.swift */,
 				870121FB20F4D2F6001E6342 /* GenericHashBuilderTests.swift */,
 				54B949931D2541350041CC55 /* TestHelper.swift */,

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -1,0 +1,152 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// See https://libsodium.gitbook.io/doc/secret-key_cryptography/aead/aes-256-gcm
+
+public enum AES256CGMEncryption {
+
+    enum EncryptionError: Error {
+
+        case failureInitializingSodium
+        case implementationNotAvailable
+        case malformedKey
+        case malformedNonce
+        case malformedCipher
+        case failedToDecrypt
+
+    }
+
+    // MARK: - Helpers
+
+    private static let keyLength = Int(crypto_aead_aes256gcm_KEYBYTES)
+    private static let nonceLength = Int(crypto_aead_aes256gcm_NPUBBYTES)
+    private static let authenticationBytesLength = Int(crypto_aead_aes256gcm_ABYTES)
+
+    private static func cipherLength(forMessageLength messageLength: Int) -> Int {
+        return messageLength + authenticationBytesLength
+    }
+
+    private static func messageLength(forCipherLength cipherLength: Int) -> Int {
+        return cipherLength - authenticationBytesLength
+    }
+
+    private static func verifyKey(bytes: [Byte]) throws {
+        guard bytes.count == keyLength else { throw EncryptionError.malformedKey }
+    }
+
+    private static func verifyNonce(bytes: [Byte]) throws {
+        guard bytes.count == nonceLength else { throw EncryptionError.malformedNonce }
+    }
+
+    private static func verifyCipher(length: UInt64) throws {
+        guard length >= UInt64(authenticationBytesLength) else { throw EncryptionError.malformedCipher }
+    }
+
+    private static func createByteArray(length: Int) -> [Byte] {
+        return [Byte](repeating: 0, count: length)
+    }
+
+    private static func initializeSodium() throws {
+        guard sodium_init() >= 0 else { throw EncryptionError.failureInitializingSodium }
+        guard isImplementationAvailable else { throw EncryptionError.implementationNotAvailable }
+    }
+
+    private static var isImplementationAvailable: Bool {
+        return crypto_aead_aes256gcm_is_available() != 0
+    }
+
+    static func generateRandomNonceBytes() -> [Byte] {
+        var nonce = createByteArray(length: nonceLength)
+        randombytes_buf(&nonce, nonce.count)
+        return nonce
+    }
+
+    /// Encrypts a message with a key.
+    ///
+    /// - Parameters:
+    ///  - message: The message data to encrypt.
+    ///  - key: The key used to encrypt.
+    ///
+    /// - Returns: The cipher and public nonce used in the encryption.
+
+    static func encrypt(message: Data, key: Data) throws -> (cipher: Data, nonce: Data) {
+        try initializeSodium()
+
+        let keyBytes = key.bytes
+        try verifyKey(bytes: keyBytes)
+
+        let messageBytes = message.bytes
+        let messageLength = messageBytes.count
+
+        let nonceBytes = generateRandomNonceBytes()
+
+        var cipherBytes = createByteArray(length: cipherLength(forMessageLength: messageLength))
+        var actualCipherLength: UInt64 = 0
+
+        crypto_aead_aes256gcm_encrypt(
+            &cipherBytes,          // buffer in which enrypted data is written to
+            &actualCipherLength,   // actual size of encrypted data
+            messageBytes,          // message to encrypt
+            UInt64(messageLength), // length of message to encrypt
+            nil,                   // additional (non encrypted) data
+            0,                     // additional data length
+            nil,                   // nsec, not used by this function
+            nonceBytes,            // unique nonce used as initizalization vector
+            keyBytes               // key used to encrypt the message
+        )
+
+        try verifyCipher(length: actualCipherLength)
+
+        return (cipherBytes.data, nonceBytes.data)
+    }
+
+    static func decrypt(cipher: Data, nonce: Data, key: Data) throws -> Data {
+        try initializeSodium()
+
+        let keyBytes = key.bytes
+        try verifyKey(bytes: keyBytes)
+
+        let nonceBytes = nonce.bytes
+        try verifyKey(bytes: nonceBytes)
+
+        let cipherBytes = cipher.bytes
+        let cipherLength = cipherBytes.count
+
+        var messageBytes = createByteArray(length: messageLength(forCipherLength: cipherLength))
+        var actualMessageLength: UInt64 = 0
+
+        let result = crypto_aead_aes256gcm_decrypt(
+            &messageBytes,          // buffer in which decrypted data is written to
+            &actualMessageLength,   // actual size of decrypted data
+            nil,                    // nsec, not used by this function
+            cipherBytes,            // cipher to decrypt
+            UInt64(cipherLength),   // length of cipher
+            nil,                    // additional (non encrypted) data
+            0,                      // additional data length
+            nonceBytes,             // the unique nonce used to encrypt the original message
+            keyBytes                // the key used to encrypt the original message
+        )
+
+        guard result == 0 else { throw EncryptionError.failedToDecrypt }
+
+        return Data(messageBytes)
+    }
+
+}

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -32,7 +32,7 @@ public enum AES256GCMEncryption {
     ///
     /// - Returns: The cipher and public nonce used in the encryption.
 
-    static func encrypt(message: Data, key: Data) throws -> (cipher: Data, nonce: Data) {
+    public static func encrypt(message: Data, key: Data) throws -> (cipher: Data, nonce: Data) {
         try initializeSodium()
 
         let keyBytes = key.bytes
@@ -72,7 +72,7 @@ public enum AES256GCMEncryption {
     ///
     /// - Returns: The plaintext message data.
 
-    static func decrypt(cipher: Data, nonce: Data, key: Data) throws -> Data {
+    public static func decrypt(cipher: Data, nonce: Data, key: Data) throws -> Data {
         try initializeSodium()
 
         let keyBytes = key.bytes

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -110,7 +110,7 @@ public enum AES256GCMEncryption {
         case implementationNotAvailable
         case malformedKey
         case malformedNonce
-        case malformedCipher
+        case malformedCiphertext
         case failedToDecrypt
 
         var errorDescription: String? {
@@ -123,8 +123,8 @@ public enum AES256GCMEncryption {
                 return "Encountered a malformed key."
             case .malformedNonce:
                 return "Encountered a malformed nonce."
-            case .malformedCipher:
-                return "Encountered a malformed cipher."
+            case .malformedCiphertext:
+                return "Encountered a malformed ciphertext."
             case .failedToDecrypt:
                 return "Failed to decrypt."
             }
@@ -154,7 +154,7 @@ public enum AES256GCMEncryption {
     }
 
     private static func verifyCipher(length: UInt64) throws {
-        guard length >= UInt64(authenticationBytesLength) else { throw EncryptionError.malformedCipher }
+        guard length >= UInt64(authenticationBytesLength) else { throw EncryptionError.malformedCiphertext }
     }
 
     // MARK: - Buffer Lengths

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -104,21 +104,38 @@ public enum AES256GCMEncryption {
         return Data(messageBytes)
     }
 
-    enum EncryptionError: Error {
+    enum EncryptionError: LocalizedError {
 
-        case failureInitializingSodium
+        case failedToInitializeSodium
         case implementationNotAvailable
         case malformedKey
         case malformedNonce
         case malformedCipher
         case failedToDecrypt
 
+        var errorDescription: String? {
+            switch self {
+            case .failedToInitializeSodium:
+                return "Failed to initialize sodium."
+            case .implementationNotAvailable:
+                return "AES256GCM implementation not available on this device."
+            case .malformedKey:
+                return "Encountered a malformed key."
+            case .malformedNonce:
+                return "Encountered a malformed nonce."
+            case .malformedCipher:
+                return "Encountered a malformed cipher."
+            case .failedToDecrypt:
+                return "Failed to decrypt."
+            }
+        }
+
     }
 
     // MARK: - Private Helpers
 
     private static func initializeSodium() throws {
-        guard sodium_init() >= 0 else { throw EncryptionError.failureInitializingSodium }
+        guard sodium_init() >= 0 else { throw EncryptionError.failedToInitializeSodium }
         guard isImplementationAvailable else { throw EncryptionError.implementationNotAvailable }
     }
 

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// See https://libsodium.gitbook.io/doc/secret-key_cryptography/aead/aes-256-gcm
 
-public enum AES256CGMEncryption {
+public enum AES256GCMEncryption {
 
     // MARK: - Public Functions
 

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -79,7 +79,7 @@ public enum AES256GCMEncryption {
         try verifyKey(bytes: keyBytes)
 
         let nonceBytes = nonce.bytes
-        try verifyKey(bytes: nonceBytes)
+        try verifyNonce(bytes: nonceBytes)
 
         let cipherBytes = cipher.bytes
         let cipherLength = cipherBytes.count

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -22,6 +22,14 @@ import Foundation
 
 public enum AES256GCMEncryption {
 
+    // MARK: - Public Properties
+
+    /// Whether the device hardware supports this encryption algorithm.
+
+    public static var isImplementationAvailable: Bool {
+        return crypto_aead_aes256gcm_is_available() != 0
+    }
+
     // MARK: - Public Functions
 
     /// Encrypts a message with a key.
@@ -145,10 +153,6 @@ public enum AES256GCMEncryption {
     private static func initializeSodium() throws {
         guard sodium_init() >= 0 else { throw EncryptionError.failedToInitializeSodium }
         guard isImplementationAvailable else { throw EncryptionError.implementationNotAvailable }
-    }
-
-    private static var isImplementationAvailable: Bool {
-        return crypto_aead_aes256gcm_is_available() != 0
     }
 
     // MARK: - Verification

--- a/WireCryptobox/AES256GCMEncryption.swift
+++ b/WireCryptobox/AES256GCMEncryption.swift
@@ -120,7 +120,7 @@ public enum AES256GCMEncryption {
         return Data(messageBytes)
     }
 
-    enum EncryptionError: LocalizedError {
+    public enum EncryptionError: LocalizedError {
 
         case failedToInitializeSodium
         case implementationNotAvailable
@@ -129,7 +129,7 @@ public enum AES256GCMEncryption {
         case malformedCiphertext
         case failedToDecrypt
 
-        var errorDescription: String? {
+        public var errorDescription: String? {
             switch self {
             case .failedToInitializeSodium:
                 return "Failed to initialize sodium."

--- a/WireCryptobox/Byte.swift
+++ b/WireCryptobox/Byte.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+typealias Byte = UInt8
+
+extension Data {
+
+    var bytes: [Byte] {
+        return [Byte](self)
+    }
+
+}
+
+extension Sequence where Element == Byte {
+
+    var data: Data {
+        return Data(self)
+    }
+
+}

--- a/WireCryptoboxTests/AES256GCMEncryptionTests.swift
+++ b/WireCryptoboxTests/AES256GCMEncryptionTests.swift
@@ -27,8 +27,8 @@ class AES256GCMEncryptionTests: XCTestCase {
 
     private typealias Sut = AES256GCMEncryption
 
-    private func generateRandomCipher(length: UInt) -> Data {
-        // Large enough to include authentication bytes in the cipher.
+    private func generateRandomCiphertext(length: UInt) -> Data {
+        // Large enough to include authentication bytes in the ciphertext.
         return Data.secureRandomData(length: length + UInt(crypto_aead_aes256gcm_ABYTES))
     }
 
@@ -42,14 +42,14 @@ class AES256GCMEncryptionTests: XCTestCase {
         let key = Data.zmRandomSHA256Key()
 
         // When
-        let (cipher, nonce) = try Sut.encrypt(message: message, context: context, key: key)
+        let (ciphertext, nonce) = try Sut.encrypt(message: message, context: context, key: key)
 
         // Then
-        XCTAssertNotEqual(cipher, message)
+        XCTAssertNotEqual(ciphertext, message)
         XCTAssertFalse(nonce.isEmpty)
 
         // When
-        let decryptedMessage = try Sut.decrypt(cipher: cipher, nonce: nonce, context: context, key: key)
+        let decryptedMessage = try Sut.decrypt(ciphertext: ciphertext, nonce: nonce, context: context, key: key)
 
         // Then
         XCTAssertEqual(decryptedMessage, message)
@@ -74,13 +74,13 @@ class AES256GCMEncryptionTests: XCTestCase {
 
     func testThatItFailsToDecryptIfKeyIsMalformed() throws {
         // Given
-        let cipher = generateRandomCipher(length: 8)
+        let ciphertext = generateRandomCiphertext(length: 8)
         let nonce = Sut.generateRandomNonceBytes().data
         let keyOfWrongLength = Data.zmRandomSHA256Key().dropLast()
 
         do {
             // When
-            _ = try Sut.decrypt(cipher: cipher, nonce: nonce, context: context, key: keyOfWrongLength)
+            _ = try Sut.decrypt(ciphertext: ciphertext, nonce: nonce, context: context, key: keyOfWrongLength)
         } catch let error as Sut.EncryptionError {
             // Then
             XCTAssertEqual(error, .malformedKey)
@@ -91,13 +91,13 @@ class AES256GCMEncryptionTests: XCTestCase {
 
     func testThatItFailsToDecryptIfNonceIsMalformed() throws {
         // Given
-        let cipher = generateRandomCipher(length: 8)
+        let ciphertext = generateRandomCiphertext(length: 8)
         let nonceOfWrongLength = Sut.generateRandomNonceBytes().data.dropLast()
         let key = Data.zmRandomSHA256Key()
 
         do {
             // When
-            _ = try Sut.decrypt(cipher: cipher, nonce: nonceOfWrongLength, context: context, key: key)
+            _ = try Sut.decrypt(ciphertext: ciphertext, nonce: nonceOfWrongLength, context: context, key: key)
         } catch let error as Sut.EncryptionError {
             // Then
             XCTAssertEqual(error, .malformedNonce)
@@ -113,11 +113,11 @@ class AES256GCMEncryptionTests: XCTestCase {
         let key1 = Data.zmRandomSHA256Key()
         let key2 = Data.zmRandomSHA256Key()
 
-        let (cipher, nonce) = try Sut.encrypt(message: message, context: context, key: key1)
+        let (ciphertext, nonce) = try Sut.encrypt(message: message, context: context, key: key1)
 
         do {
             // When
-            _ = try Sut.decrypt(cipher: cipher, nonce: nonce, context: context, key: key2)
+            _ = try Sut.decrypt(ciphertext: ciphertext, nonce: nonce, context: context, key: key2)
         } catch let error as Sut.EncryptionError {
             // Then
             XCTAssertEqual(error, .failedToDecrypt)
@@ -132,11 +132,11 @@ class AES256GCMEncryptionTests: XCTestCase {
         let key = Data.zmRandomSHA256Key()
         let randomNonce = Sut.generateRandomNonceBytes().data
 
-        let (cipher, _) = try Sut.encrypt(message: message, context: context, key: key)
+        let (ciphertext, _) = try Sut.encrypt(message: message, context: context, key: key)
 
         do {
             // When
-            _ = try Sut.decrypt(cipher: cipher, nonce: randomNonce, context: context, key: key)
+            _ = try Sut.decrypt(ciphertext: ciphertext, nonce: randomNonce, context: context, key: key)
         } catch let error as Sut.EncryptionError {
             // Then
             XCTAssertEqual(error, .failedToDecrypt)
@@ -151,11 +151,11 @@ class AES256GCMEncryptionTests: XCTestCase {
         let key = Data.zmRandomSHA256Key()
         let randomNonce = Sut.generateRandomNonceBytes().data
 
-        let (cipher, _) = try Sut.encrypt(message: message, context: context, key: key)
+        let (ciphertext, _) = try Sut.encrypt(message: message, context: context, key: key)
 
         do {
             // When
-            _ = try Sut.decrypt(cipher: cipher, nonce: randomNonce, context: context.dropFirst(), key: key)
+            _ = try Sut.decrypt(ciphertext: ciphertext, nonce: randomNonce, context: context.dropFirst(), key: key)
         } catch let error as Sut.EncryptionError {
             // Then
             XCTAssertEqual(error, .failedToDecrypt)

--- a/WireCryptoboxTests/AES256GCMEncryptionTests.swift
+++ b/WireCryptoboxTests/AES256GCMEncryptionTests.swift
@@ -1,0 +1,134 @@
+//
+//  AES256GCMEncryptionTests.swift
+//  WireCryptoboxTests
+//
+//  Created by John Nguyen on 06.08.20.
+//  Copyright © 2020 Cryptobox. All rights reserved.
+//
+
+import XCTest
+@testable import WireCryptobox
+
+class AES256GCMEncryptionTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private typealias Sut = AES256CGMEncryption
+
+    private func generateRandomCipher(length: UInt) -> Data {
+        // Large enough to include authentication bytes in the cipher.
+        return Data.secureRandomData(length: length + UInt(crypto_aead_aes256gcm_ABYTES))
+    }
+
+    // MARK: - Positive Tests
+
+    func testThatItEncryptsAndDecryptsMessage() throws {
+        // Given
+        let message = "Hello, world".data(using: .utf8)!
+        let key = Data.zmRandomSHA256Key()
+
+        // When
+        let (cipher, nonce) = try Sut.encrypt(message: message, key: key)
+
+        // Then
+        XCTAssertNotEqual(cipher, message)
+        XCTAssertFalse(nonce.isEmpty)
+
+        // When
+        let decryptedMessage = try Sut.decrypt(cipher: cipher, nonce: nonce, key: key)
+
+        // Then
+        XCTAssertEqual(decryptedMessage, message)
+    }
+
+    // MARK: - Negative Tests
+
+    func testThatItFailsToEncryptIfKeyIsMalformed() throws {
+        // Given
+        let keyOfWrongLength = Data.zmRandomSHA256Key().dropLast()
+
+        do {
+            // When
+            _ = try Sut.encrypt(message: Data(), key: keyOfWrongLength)
+        } catch let error as Sut.EncryptionError {
+            // Then
+            XCTAssertEqual(error, .malformedKey)
+        } catch {
+            XCTFail("Unexpected error: \(error.localizedDescription)")
+        }
+    }
+
+    func testThatItFailsToDecryptIfKeyIsMalformed() throws {
+        // Given
+        let cipher = generateRandomCipher(length: 8)
+        let nonce = Sut.generateRandomNonceBytes().data
+        let keyOfWrongLength = Data.zmRandomSHA256Key().dropLast()
+
+        do {
+            // When
+            _ = try Sut.decrypt(cipher: cipher, nonce: nonce, key: keyOfWrongLength)
+        } catch let error as Sut.EncryptionError {
+            // Then
+            XCTAssertEqual(error, .malformedKey)
+        } catch {
+            XCTFail("Unexpected error: \(error.localizedDescription)")
+        }
+    }
+
+    func testThatItFailsToDecryptIfNonceIsMalformed() throws {
+        // Given
+        let cipher = generateRandomCipher(length: 8)
+        let nonceOfWrongLength = Sut.generateRandomNonceBytes().data.dropLast()
+        let key = Data.zmRandomSHA256Key()
+
+        do {
+            // When
+            _ = try Sut.decrypt(cipher: cipher, nonce: nonceOfWrongLength, key: key)
+        } catch let error as Sut.EncryptionError {
+            // Then
+            XCTAssertEqual(error, .malformedNonce)
+        } catch {
+            XCTFail("Unexpected error: \(error.localizedDescription)")
+        }
+    }
+
+
+    func testThatItFailsToDecryptWithDifferentKey() throws {
+        // Given
+        let message = "Hello, world".data(using: .utf8)!
+        let key1 = Data.zmRandomSHA256Key()
+        let key2 = Data.zmRandomSHA256Key()
+
+        let (cipher, nonce) = try Sut.encrypt(message: message, key: key1)
+
+        do {
+            // When
+            _ = try Sut.decrypt(cipher: cipher, nonce: nonce, key: key2)
+        } catch let error as Sut.EncryptionError {
+            // Then
+            XCTAssertEqual(error, .failedToDecrypt)
+        } catch {
+            XCTFail("Unexpected error: \(error.localizedDescription)")
+        }
+    }
+
+    func testThatItFailsToDecryptWithDifferentNonce() throws {
+        // Given
+        let message = "Hello, world".data(using: .utf8)!
+        let key = Data.zmRandomSHA256Key()
+        let randomNonce = Sut.generateRandomNonceBytes().data
+
+        let (cipher, _) = try Sut.encrypt(message: message, key: key)
+
+        do {
+            // When
+            _ = try Sut.decrypt(cipher: cipher, nonce: randomNonce, key: key)
+        } catch let error as Sut.EncryptionError {
+            // Then
+            XCTAssertEqual(error, .failedToDecrypt)
+        } catch {
+            XCTFail("Unexpected error: \(error.localizedDescription)")
+        }
+    }
+
+}

--- a/WireCryptoboxTests/AES256GCMEncryptionTests.swift
+++ b/WireCryptoboxTests/AES256GCMEncryptionTests.swift
@@ -32,8 +32,6 @@ class AES256GCMEncryptionTests: XCTestCase {
         return Data.secureRandomData(length: length + UInt(crypto_aead_aes256gcm_ABYTES))
     }
 
-    // Test for context.
-
     // MARK: - Positive Tests
 
     func testThatItEncryptsAndDecryptsMessage() throws {

--- a/WireCryptoboxTests/AES256GCMEncryptionTests.swift
+++ b/WireCryptoboxTests/AES256GCMEncryptionTests.swift
@@ -23,7 +23,7 @@ class AES256GCMEncryptionTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private typealias Sut = AES256CGMEncryption
+    private typealias Sut = AES256GCMEncryption
 
     private func generateRandomCipher(length: UInt) -> Data {
         // Large enough to include authentication bytes in the cipher.

--- a/WireCryptoboxTests/AES256GCMEncryptionTests.swift
+++ b/WireCryptoboxTests/AES256GCMEncryptionTests.swift
@@ -1,9 +1,19 @@
 //
-//  AES256GCMEncryptionTests.swift
-//  WireCryptoboxTests
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by John Nguyen on 06.08.20.
-//  Copyright © 2020 Cryptobox. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import XCTest


### PR DESCRIPTION
## What's new in this PR?

This PR contains a Swift wrapper for the AES256-GCM encryption and decryption methods from lib sodium.

### Notes

In this repository we also provide a wrapper around ChaCha20, and I see some opportunities to refactor these two wrappers to avoid some duplication and improve consistency between them. I will address these issues in a separate PR so as not to clutter this one.