### PR TITLE
Add extensive logging of specific sessions

### DIFF
--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -57,6 +57,9 @@ public final class EncryptionSessionsDirectory : NSObject {
     /// will not try to validate with the generating context
     var debug_disableContextValidityCheck = false
     
+    /// Set of session identifier that require full debugging logs
+    private var extensiveLoggingSessions = Set<EncryptionSessionIdentifier>()
+    
     /// Context that created this status
     fileprivate weak var generatingContext: EncryptionContext!
     
@@ -107,6 +110,14 @@ public final class EncryptionSessionsDirectory : NSObject {
     
     deinit {
         self.commitCache()
+    }
+    
+    func setExtendedLogging(identifier: EncryptionSessionIdentifier, enabled: Bool) {
+        if (enabled) {
+            self.extensiveLoggingSessions.insert(identifier)
+        } else {
+            self.extensiveLoggingSessions.remove(identifier)
+        }
     }
     
     private func hash(for data: Data, recipient: EncryptionSessionIdentifier) -> GenericHash {
@@ -241,7 +252,8 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
         let session = EncryptionSession(id: identifier,
                                         session: cbsession,
                                         requiresSave: true,
-                                        cryptoboxPath: self.generatingContext!.path)
+                                        cryptoboxPath: self.generatingContext!.path,
+                                        extensiveLogging: self.extensiveLoggingSessions.contains(identifier))
         self.pendingSessionsCache[identifier] = session
         
         zmLog.safePublic("Created session for client \(identifier) - fingerprint \(session.remoteFingerprint)")
@@ -267,7 +279,8 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
         let session = EncryptionSession(id: identifier,
                                         session: cbsession,
                                         requiresSave: true,
-                                        cryptoboxPath: self.generatingContext!.path)
+                                        cryptoboxPath: self.generatingContext!.path,
+                                        extensiveLogging: self.extensiveLoggingSessions.contains(identifier))
         self.pendingSessionsCache[identifier] = session
 
         zmLog.safePublic("Created session for client \(identifier) from prekey message - fingerprint \(session.remoteFingerprint)")
@@ -307,7 +320,8 @@ extension EncryptionSessionsDirectory: EncryptionSessionManager {
             let session = EncryptionSession(id: identifier,
                                             session: cbsession,
                                             requiresSave: false,
-                                            cryptoboxPath: self.generatingContext!.path)
+                                            cryptoboxPath: self.generatingContext!.path,
+                                            extensiveLogging: self.extensiveLoggingSessions.contains(identifier))
             self.pendingSessionsCache[identifier] = session
             zmLog.safePublic("Loaded session for client \(identifier) - fingerprint \(session.remoteFingerprint)")
             return session
@@ -468,19 +482,24 @@ class EncryptionSession {
     /// Path of the containing cryptobox (used for debugging)
     let cryptoboxPath : URL
     
+    /// Whether to log additional information
+    let extensiveLogging: Bool
+    
     /// Creates a session from a C-level session pointer
     /// - parameter id: id of the client
     /// - parameter requiresSave: if true, mark this session as having pending changes to save
     init(id: EncryptionSessionIdentifier,
          session: _CBoxSession,
          requiresSave: Bool,
-         cryptoboxPath: URL
+         cryptoboxPath: URL,
+         extensiveLogging: Bool
         ) {
         self.id = id
         self.implementation = session
         self.remoteFingerprint = session.remoteFingerprint
         self.hasChanges = requiresSave
         self.cryptoboxPath = cryptoboxPath
+        self.extensiveLogging = extensiveLogging
     }
     
     /// Closes the session in CBox
@@ -564,9 +583,16 @@ extension EncryptionSession {
                          &vectorBacking)
         }
         
-        if (result != CBOX_DUPLICATE_MESSAGE && result != CBOX_SUCCESS) {
+        let resultRequiresLogging = result != CBOX_DUPLICATE_MESSAGE && result != CBOX_SUCCESS
+        if (resultRequiresLogging || self.extensiveLogging) {
             let encodedData = HexDumpUnsafeLoggingData(data: cypher)
-            zmLog.safePublic("Failed to decrypt cyphertext: \(encodedData)")
+            if (self.extensiveLogging) {
+                zmLog.safePublic(
+                    "Extensive logging: decrypting cryphertext: result \(result): \(encodedData)"
+                )
+            } else {
+                zmLog.safePublic("Failed to decrypt cyphertext: \(encodedData)")
+            }
         }
         
         try result.throwIfError()
@@ -587,11 +613,17 @@ extension EncryptionSession {
                          plainText.count,
                          &vectorBacking)
         }
-        
+                
         try result.throwIfError()
 
         self.hasChanges = true
-        return Data.moveFromCBoxVector(vectorBacking)!
+        let data = Data.moveFromCBoxVector(vectorBacking)!
+        
+        if (self.extensiveLogging) {
+            let encodedData = HexDumpUnsafeLoggingData(data: data)
+            zmLog.safePublic("Extensive logging: encrypted to cryphertext: \(encodedData)")
+        }
+        return data
     }
 }
 

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -493,7 +493,7 @@ class EncryptionSession {
     let cryptoboxPath : URL
     
     /// Whether to log additional information
-    let extensiveLogging: Bool
+    let isExtensiveLoggingEnabled: Bool
     
     /// Creates a session from a C-level session pointer
     /// - parameter id: id of the client
@@ -509,7 +509,7 @@ class EncryptionSession {
         self.remoteFingerprint = session.remoteFingerprint
         self.hasChanges = requiresSave
         self.cryptoboxPath = cryptoboxPath
-        self.extensiveLogging = extensiveLogging
+        self.isExtensiveLoggingEnabled = extensiveLogging
     }
     
     /// Closes the session in CBox
@@ -594,9 +594,9 @@ extension EncryptionSession {
         }
         
         let resultRequiresLogging = result != CBOX_DUPLICATE_MESSAGE && result != CBOX_SUCCESS
-        if (resultRequiresLogging || self.extensiveLogging) {
+        if (resultRequiresLogging || self.isExtensiveLoggingEnabled) {
             let encodedData = HexDumpUnsafeLoggingData(data: cypher)
-            if (self.extensiveLogging) {
+            if (self.isExtensiveLoggingEnabled) {
                 zmLog.safePublic(
                     "Extensive logging: decrypting cyphertext: session \(id): result \(result): \(encodedData)", level: .public
                 )
@@ -629,7 +629,7 @@ extension EncryptionSession {
         self.hasChanges = true
         let data = Data.moveFromCBoxVector(vectorBacking)!
         
-        if (self.extensiveLogging) {
+        if (self.isExtensiveLoggingEnabled) {
             let encodedData = HexDumpUnsafeLoggingData(data: data)
             zmLog.safePublic("Extensive logging: encrypted to cyphertext: session \(id): \(encodedData)", level: .public)
         }

--- a/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -289,7 +289,7 @@ extension EncryptionSessionsDirectoryTests {
         
         // GIVEN
         let plainText = "foo".data(using: String.Encoding.utf8)!
-        try! statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(1))
+        establishSessionFromAliceToBob()
         
         // WHEN
         statusAlice = nil
@@ -306,7 +306,7 @@ extension EncryptionSessionsDirectoryTests {
     func testThatNewlyCreatedSessionsAreNotSavedWhenDiscarding() {
         
         // GIVEN
-        try! statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(1))
+        establishSessionFromAliceToBob()
         
         // WHEN
         statusAlice.discardCache()
@@ -324,7 +324,7 @@ extension EncryptionSessionsDirectoryTests {
         
         // GIVEN
         let plainText = "foo".data(using: String.Encoding.utf8)!
-        try! statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(1))
+        establishSessionFromAliceToBob()
         let prekeyMessage = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
         _ = try! statusBob.createClientSessionAndReturnPlaintext(for: Person.Alice.identifier, prekeyMessage: prekeyMessage)
         self.recreateStatuses() // force save
@@ -346,7 +346,7 @@ extension EncryptionSessionsDirectoryTests {
     func testThatItCanNotDecodeAfterDiscardingCache() {
         
         // GIVEN
-        try! statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(34))
+        establishSessionFromAliceToBob()
         
         // WHEN
         statusAlice.discardCache()
@@ -454,7 +454,7 @@ extension EncryptionSessionsDirectoryTests {
         
         // GIVEN
         let plainText = "foo".data(using: String.Encoding.utf8)!
-        try! statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(34))
+        establishSessionFromAliceToBob()
         
         // WHEN
         self.recreateStatuses() // force save
@@ -558,6 +558,152 @@ extension EncryptionSessionsDirectoryTests {
         XCTAssertTrue(checkThatAMessageCanBeSent(.Bob))
     }
 }
+
+// MARK: - Extended logging
+extension EncryptionSessionsDirectoryTests {
+    
+    func testThatItLogsEncryptionWhenExtendedEncryptionIsSet() {
+        
+        // GIVEN
+        statusAlice.setExtendedLogging(identifier: Person.Bob.identifier, enabled: true)
+        
+        let plainText = "foo".data(using: String.Encoding.utf8)!
+        establishSessionFromAliceToBob()
+        let logExpectation = expectation(description: "Encrypting")
+        
+        
+        // EXPECT
+        let token = ZMSLog.addEntryHook { (level, tag, entry, isSafe) in
+            if level == ZMLogLevel_t.public &&
+                tag == "cryptobox" &&
+                entry.text.starts(with: "Extensive logging: encrypted to cyphertext:")
+            {
+                logExpectation.fulfill()
+            }
+        }
+                
+        // WHEN
+        _ = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
+        
+        // THEN
+        waitForExpectations(timeout: 0.2)
+        
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
+    }
+    
+    func testThatItDoesNotLogEncryptionWhenExtendedEncryptionIsNotSet() {
+        
+        // GIVEN
+        // set logging for a different identifier
+        let wrongIdentifier = EncryptionSessionIdentifier(userId: "foo", clientId: "bar")
+        statusAlice.setExtendedLogging(identifier: wrongIdentifier, enabled: true)
+        
+        let plainText = "foo".data(using: String.Encoding.utf8)!
+        do {
+            try statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(2))
+        } catch {
+            XCTFail()
+            return
+        }
+        
+        // EXPECT
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
+            XCTFail("Should not have logged")
+        }
+        
+        // WHEN
+        _ = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
+        
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
+    }
+    
+    func testThatItLogsDecryptionWhenExtendedEncryptionIsSet_prekeyMessage() {
+        
+        // GIVEN
+        statusBob.setExtendedLogging(identifier: Person.Alice.identifier, enabled: true)
+        
+        let plainText = "foo".data(using: String.Encoding.utf8)!
+        establishSessionFromAliceToBob()
+        let logExpectation = expectation(description: "Encrypting")
+        let prekeyMessage = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
+        
+        // EXPECT
+        let token = ZMSLog.addEntryHook { (level, tag, entry, isSafe) in
+            if level == ZMLogLevel_t.public &&
+                tag == "cryptobox" &&
+                entry.text.starts(with: "Extensive logging: decrypting prekey cyphertext:")
+            {
+                logExpectation.fulfill()
+            }
+        }
+                
+        // WHEN
+        _ = try! statusBob.createClientSessionAndReturnPlaintext(for: Person.Alice.identifier, prekeyMessage: prekeyMessage)
+        
+        // THEN
+        waitForExpectations(timeout: 0.2)
+        
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
+    }
+    
+    func testThatItLogsDecryptionWhenExtendedEncryptionIsSet_nonPrekeyMessage() {
+        
+        // GIVEN
+        
+        let plainText = "foo".data(using: String.Encoding.utf8)!
+        establishSessionBetweenAliceAndBob()
+        statusBob.setExtendedLogging(identifier: Person.Alice.identifier, enabled: true)
+        let logExpectation = expectation(description: "Encrypting")
+        let message = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
+        
+        // EXPECT
+        let token = ZMSLog.addEntryHook { (level, tag, entry, isSafe) in
+            if level == ZMLogLevel_t.public &&
+                tag == "cryptobox" &&
+                entry.text.starts(with: "Extensive logging: decrypting cyphertext:")
+            {
+                logExpectation.fulfill()
+            }
+        }
+                
+        // WHEN
+        _ = try! statusBob.decrypt(message, from: Person.Alice.identifier)
+        
+        // THEN
+        waitForExpectations(timeout: 0.2)
+        
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
+    }
+    
+    func testThatItDoesNotLogDecryptionWhenExtendedEncryptionIsNotSet() {
+        
+        // GIVEN
+        // set logging for a different identifier
+        let wrongIdentifier = EncryptionSessionIdentifier(userId: "foo", clientId: "bar")
+        statusBob.setExtendedLogging(identifier: wrongIdentifier, enabled: true)
+
+        let plainText = "foo".data(using: String.Encoding.utf8)!
+        establishSessionFromAliceToBob()
+        
+        let prekeyMessage = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
+        
+        // EXPECT
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
+            XCTFail("Should not have logged")
+        }
+        
+        // WHEN
+        _ = try! statusBob.createClientSessionAndReturnPlaintext(for: Person.Alice.identifier, prekeyMessage: prekeyMessage)
+        
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
+    }
+}
+
 
 // MARK: - Helpers
 

--- a/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -562,7 +562,7 @@ extension EncryptionSessionsDirectoryTests {
 // MARK: - Extended logging
 extension EncryptionSessionsDirectoryTests {
     
-    func testThatItLogsEncryptionWhenExtendedEncryptionIsSet() {
+    func testThatItLogsEncryptionWhenExtendedLoggingIsSet() {
         
         // GIVEN
         statusAlice.setExtendedLogging(identifier: Person.Bob.identifier, enabled: true)
@@ -592,7 +592,7 @@ extension EncryptionSessionsDirectoryTests {
         ZMSLog.removeLogHook(token: token)
     }
     
-    func testThatItDoesNotLogEncryptionWhenExtendedEncryptionIsNotSet() {
+    func testThatItDoesNotLogEncryptionWhenExtendedLoggingIsNotSet() {
         
         // GIVEN
         // set logging for a different identifier
@@ -614,7 +614,7 @@ extension EncryptionSessionsDirectoryTests {
         ZMSLog.removeLogHook(token: token)
     }
     
-    func testThatItDoesNotLogEncryptionWhenRemovingExtendedEncryption() {
+    func testThatItDoesNotLogEncryptionWhenRemovingExtendedLogging() {
         
         // GIVEN
         statusAlice.setExtendedLogging(identifier: Person.Bob.identifier, enabled: true)
@@ -637,7 +637,7 @@ extension EncryptionSessionsDirectoryTests {
         ZMSLog.removeLogHook(token: token)
     }
     
-    func testThatItLogsDecryptionWhenExtendedEncryptionIsSet_prekeyMessage() {
+    func testThatItLogsDecryptionWhenExtendedLoggingIsSet_prekeyMessage() {
         
         // GIVEN
         statusBob.setExtendedLogging(identifier: Person.Alice.identifier, enabled: true)
@@ -667,7 +667,7 @@ extension EncryptionSessionsDirectoryTests {
         ZMSLog.removeLogHook(token: token)
     }
     
-    func testThatItLogsDecryptionWhenExtendedEncryptionIsSet_nonPrekeyMessage() {
+    func testThatItLogsDecryptionWhenExtendedLoggingIsSet_nonPrekeyMessage() {
         
         // GIVEN
         
@@ -697,7 +697,7 @@ extension EncryptionSessionsDirectoryTests {
         ZMSLog.removeLogHook(token: token)
     }
     
-    func testThatItDoesNotLogDecryptionWhenExtendedEncryptionIsNotSet() {
+    func testThatItDoesNotLogDecryptionWhenExtendedLoggingIsNotSet() {
         
         // GIVEN
         // set logging for a different identifier

--- a/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -600,12 +600,30 @@ extension EncryptionSessionsDirectoryTests {
         statusAlice.setExtendedLogging(identifier: wrongIdentifier, enabled: true)
         
         let plainText = "foo".data(using: String.Encoding.utf8)!
-        do {
-            try statusAlice.createClientSession(Person.Bob.identifier, base64PreKeyString: statusBob.generatePrekey(2))
-        } catch {
-            XCTFail()
-            return
+        establishSessionFromAliceToBob()
+        
+        // EXPECT
+        let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in
+            XCTFail("Should not have logged")
         }
+        
+        // WHEN
+        _ = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
+        
+        // AFTER
+        ZMSLog.removeLogHook(token: token)
+    }
+    
+    func testThatItDoesNotLogEncryptionWhenRemovingExtendedEncryption() {
+        
+        // GIVEN
+        statusAlice.setExtendedLogging(identifier: Person.Bob.identifier, enabled: true)
+        // disable
+        statusAlice.setExtendedLogging(identifier: Person.Bob.identifier, enabled: false)
+
+        
+        let plainText = "foo".data(using: String.Encoding.utf8)!
+        establishSessionFromAliceToBob()
         
         // EXPECT
         let token = ZMSLog.addEntryHook { (_level, _tag, entry, isSafe) in


### PR DESCRIPTION
## What's new in this PR?

This PR is part of a series of changes aimed at performing extensive logging for specific users and for specific sessions. This PR adds the ability to turn on extensive logging (the cypher text of every message that is encrypted or decrypted) for a specific session.

### Testing

I created unit tests to verify that it logs when asked to, and not log when it's not asked to.