### PR TITLE
Move logging to encryption context

### DIFF
--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -58,7 +58,7 @@ public final class EncryptionSessionsDirectory : NSObject {
     var debug_disableContextValidityCheck = false
     
     /// Set of session identifier that require full debugging logs
-    private var extensiveLoggingSessions = Set<EncryptionSessionIdentifier>()
+    var extensiveLoggingSessions: Set<EncryptionSessionIdentifier>
     
     /// Context that created this status
     fileprivate weak var generatingContext: EncryptionContext!
@@ -82,10 +82,15 @@ public final class EncryptionSessionsDirectory : NSObject {
     /// load once and save once at the end.
     fileprivate var pendingSessionsCache : [EncryptionSessionIdentifier : EncryptionSession] = [:]
     
-    init(generatingContext: EncryptionContext, encryptionPayloadCache: Cache<GenericHash, Data>) {
+    init(
+        generatingContext: EncryptionContext,
+        encryptionPayloadCache: Cache<GenericHash, Data>,
+        extensiveLoggingSessions: Set<EncryptionSessionIdentifier>
+    ) {
         self.generatingContext = generatingContext
         self.localFingerprint = generatingContext.implementation.localFingerprint
         self.encryptionPayloadCache = encryptionPayloadCache
+        self.extensiveLoggingSessions = extensiveLoggingSessions
         super.init()
         zmLog.safePublic("Loaded encryption status - local fingerprint \(localFingerprint)")
     }
@@ -111,24 +116,7 @@ public final class EncryptionSessionsDirectory : NSObject {
     deinit {
         self.commitCache()
     }
-    
-    /// Enables or disables extended logging for any message encrypted from or to
-    /// a specific session.
-    /// note: if the session is already cached in memory, this will apply from the
-    /// next time the session is reloaded
-    func setExtendedLogging(identifier: EncryptionSessionIdentifier, enabled: Bool) {
-        if (enabled) {
-            self.extensiveLoggingSessions.insert(identifier)
-        } else {
-            self.extensiveLoggingSessions.remove(identifier)
-        }
-    }
-    
-    /// Disable extensive logging on all sessions
-    func disableExtendedLoggingOnAllSessions() {
-        self.extensiveLoggingSessions.removeAll()
-    }
-    
+        
     private func hash(for data: Data, recipient: EncryptionSessionIdentifier) -> GenericHash {
         let builder = GenericHashBuilder()
         builder.append(data)

--- a/WireCryptobox/EncryptionSessionsDirectory.swift
+++ b/WireCryptobox/EncryptionSessionsDirectory.swift
@@ -58,7 +58,7 @@ public final class EncryptionSessionsDirectory : NSObject {
     var debug_disableContextValidityCheck = false
     
     /// Set of session identifier that require full debugging logs
-    var extensiveLoggingSessions: Set<EncryptionSessionIdentifier>
+    let extensiveLoggingSessions: Set<EncryptionSessionIdentifier>
     
     /// Context that created this status
     fileprivate weak var generatingContext: EncryptionContext!

--- a/WireCryptoboxTests/EncryptionContextTests.swift
+++ b/WireCryptoboxTests/EncryptionContextTests.swift
@@ -18,7 +18,7 @@
 
 
 import XCTest
-import WireCryptobox
+@testable import WireCryptobox
 
 class EncryptionContextTests: XCTestCase {
 
@@ -151,7 +151,7 @@ class EncryptionContextTests: XCTestCase {
         
         // GIVEN
         let tempDir = createTempFolder()
-        
+
         let mainContext = EncryptionContext(path: tempDir)
         
         let someTextToEncrypt = "ENCRYPT THIS!"
@@ -203,5 +203,73 @@ class EncryptionContextTests: XCTestCase {
         }
         
         self.waitForExpectations(timeout: 0) { _ in }
+    }
+    
+}
+
+// MARK: - Logging
+extension EncryptionContextTests {
+    
+    func testThatItSetsExtendedLoggingOnSessions() {
+        
+        // GIVEN
+        let identifier = EncryptionSessionIdentifier(userId: "user", clientId: "foo")
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        // WHEN
+        mainContext.setExtendedLogging(identifier: identifier, enabled: true)
+        
+        // THEN
+        mainContext.perform {
+            XCTAssertEqual($0.extensiveLoggingSessions, Set([identifier]))
+        }
+    }
+    
+    func testThatItDoesSetExtendedLoggingOnSessions() {
+        
+        // GIVEN
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        // THEN
+        mainContext.perform {
+            XCTAssert($0.extensiveLoggingSessions.isEmpty)
+        }
+    }
+    
+    
+    func testThatItDoesNotLogEncryptionWhenRemovingExtendedLogging() {
+
+        // GIVEN
+        let identifier = EncryptionSessionIdentifier(userId: "user", clientId: "foo")
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        // WHEN
+        mainContext.setExtendedLogging(identifier: identifier, enabled: true)
+        mainContext.setExtendedLogging(identifier: identifier, enabled: false)
+        
+        // THEN
+        mainContext.perform {
+            XCTAssert($0.extensiveLoggingSessions.isEmpty)
+        }
+    }
+    
+    func testThatItDoesNotLogEncryptionWhenRemovingAllExtendedLogging() {
+
+        // GIVEN
+        let identifier = EncryptionSessionIdentifier(userId: "user", clientId: "foo")
+        let tempDir = createTempFolder()
+        let mainContext = EncryptionContext(path: tempDir)
+        
+        // WHEN
+        mainContext.setExtendedLogging(identifier: identifier, enabled: true)
+        mainContext.disableExtendedLoggingOnAllSessions()
+        
+        // THEN
+        mainContext.perform {
+            XCTAssert($0.extensiveLoggingSessions.isEmpty)
+        }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

Following up on #45, this moves setting the sessions to log from the `EncryptedSessionsDirectory` to `EncryptionContext`. This is because `EncryptedSessionsDirectory` is constantly created and destroyed by `EncryptionContext` and any extended log set on `EncryptedSessionsDirectory` will be lost immediately. The setting is moved to `EncryptionContext` so that it can be passed to any newly created `EncryptedSessionsDirectory`.